### PR TITLE
require faraday

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.4.0)
+    whatsapp_sdk (0.5.0)
       faraday (~> 2.3.0)
       faraday-multipart (~> 1.0.4)
       oj (~> 3.13.13)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 # typed: strict
 
 module WhatsappSdk
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/lib/whatsapp_sdk.rb
+++ b/lib/whatsapp_sdk.rb
@@ -2,11 +2,12 @@
 # typed: true
 
 require "zeitwerk"
+require "faraday"
+require "faraday/multipart"
+require "sorbet-runtime"
 
 loader = Zeitwerk::Loader.for_gem
 loader.setup
-
-require "sorbet-runtime"
 
 module WhatsappSdk
   class << self


### PR DESCRIPTION
A bug was reported that the gem required `faraday` https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/36#issuecomment-1244270213. This PR fixes it.
cc @ademir10
