### PR TITLE
Remove warnings

### DIFF
--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -2,5 +2,7 @@
 # typed: strict
 
 module WhatsappSdk
-  VERSION = "0.5.0"
+  class Version
+    VERSION = "0.5.0"
+  end
 end

--- a/test/whatsapp/api/medias_test.rb
+++ b/test/whatsapp/api/medias_test.rb
@@ -76,10 +76,14 @@ module WhatsappSdk
       end
 
       def test_upload_media_with_success_response
-        valid_response = { "id" => "123456" }
+        media_id = "123456"
+        valid_response = { "id" => media_id }
         @medias_api.expects(:send_request).returns(valid_response)
         response = @medias_api.upload(sender_id: 123, file_path: "tmp/whatsapp.png", type: "image/png")
-        assert_medias_mock_response(valid_response, response)
+
+        assert_ok_response(response)
+        assert_equal(WhatsappSdk::Api::Responses::MediaDataResponse, response.data.class)
+        assert_equal(media_id, response.data.id)
       end
 
       def test_upload_media_sends_valid_params
@@ -101,7 +105,10 @@ module WhatsappSdk
         ).returns({ "id" => media_id })
 
         response = @medias_api.upload(sender_id: 123, file_path: file_path, type: type)
-        assert_medias_mock_response({ "id" => "987654321" }, response)
+        assert_ok_response(response)
+
+        assert_equal(WhatsappSdk::Api::Responses::MediaDataResponse, response.data.class)
+        assert_equal(media_id, response.data.id)
       end
 
       def test_download_media_handles_error_response
@@ -129,11 +136,15 @@ module WhatsappSdk
       end
 
       def validate_sucess_data_response(response)
+        assert_ok_response(response)
+        assert_equal(WhatsappSdk::Api::Responses::SuccessResponse, response.data.class)
+        assert_predicate(response.data, :success?)
+      end
+
+      def assert_ok_response(response)
         assert_equal(WhatsappSdk::Api::Response, response.class)
         assert_nil(response.error)
         assert_predicate(response, :ok?)
-        assert_equal(WhatsappSdk::Api::Responses::SuccessResponse, response.data.class)
-        assert_predicate(response.data, :success?)
       end
 
       def error_response_example
@@ -181,9 +192,7 @@ module WhatsappSdk
       end
 
       def assert_medias_mock_response(expected_media_response, response)
-        assert_equal(WhatsappSdk::Api::Response, response.class)
-        assert_nil(response.error)
-        assert_predicate(response, :ok?)
+        assert_ok_response(response)
 
         assert_equal(WhatsappSdk::Api::Responses::MediaDataResponse, response.data.class)
         assert_equal(expected_media_response["id"], response.data.id)

--- a/test/whatsapp/version_test.rb
+++ b/test/whatsapp/version_test.rb
@@ -2,10 +2,10 @@
 # typed: true
 
 require "test_helper"
-require "version"
+require_relative '../../lib/whatsapp_sdk/version'
 
 class VersionTest < Minitest::Test
   def test_that_it_has_a_version_number
-    refute_nil ::WhatsappSdk::VERSION
+    assert_equal("0.5.0", WhatsappSdk::Version::VERSION)
   end
 end

--- a/whatsapp_sdk.gemspec
+++ b/whatsapp_sdk.gemspec
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 # typed: true
 
+require_relative 'lib/whatsapp_sdk/version'
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "version"
 
 Gem::Specification.new do |spec|
   spec.name = "whatsapp_sdk"
-  spec.version = WhatsappSdk::VERSION
+  spec.version = WhatsappSdk::Version::VERSION
   spec.authors       = ["ignacio-chiazzo"]
   spec.email         = ["ignaciochiazzo@gmail.com"]
   spec.summary       = "Use the Ruby Whatsapp SDK to comunicate with Whatsapp API using the Cloud API"


### PR DESCRIPTION
Remove warnings:
1) Zeitwerk `version` file warning
<img width="1421" alt="Screen Shot 2022-09-16 at 10 23 12 PM" src="https://user-images.githubusercontent.com/11672878/190836836-0d41c1ec-b98a-45d6-bacf-6e4ce662ba6c.png">

2) `assert_equals` can't be used when the value is nil in Minitest 6.

CC @ademir10

