### PR TITLE
Fix constant version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v 0.6.0
+Fix issue on Linux when files are not sorted [#45](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/45)
+
 # v 0.5.1
 Remove warnings [#41](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/41)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.5.1)
+    whatsapp_sdk (0.6.0)
       faraday (~> 2.3.0)
       faraday-multipart (~> 1.0.4)
       oj (~> 3.13.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.5.0)
+    whatsapp_sdk (0.5.1)
       faraday (~> 2.3.0)
       faraday-multipart (~> 1.0.4)
       oj (~> 3.13.13)

--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -2,5 +2,5 @@
 # typed: strict
 
 module WhatsappSdk
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end

--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -2,7 +2,5 @@
 # typed: strict
 
 module WhatsappSdk
-  class Version
-    VERSION = "0.5.1"
-  end
+  VERSION = "0.5.1"
 end

--- a/test/whatsapp/version_test.rb
+++ b/test/whatsapp/version_test.rb
@@ -6,6 +6,6 @@ require_relative '../../lib/whatsapp_sdk/version'
 
 class VersionTest < Minitest::Test
   def test_that_it_has_a_version_number
-    assert_equal("0.5.1", WhatsappSdk::VERSION)
+    assert_equal("0.6.0", WhatsappSdk::VERSION)
   end
 end

--- a/test/whatsapp/version_test.rb
+++ b/test/whatsapp/version_test.rb
@@ -6,6 +6,6 @@ require_relative '../../lib/whatsapp_sdk/version'
 
 class VersionTest < Minitest::Test
   def test_that_it_has_a_version_number
-    assert_equal("0.5.1", WhatsappSdk::Version::VERSION)
+    assert_equal("0.5.1", WhatsappSdk::VERSION)
   end
 end

--- a/whatsapp_sdk.gemspec
+++ b/whatsapp_sdk.gemspec
@@ -8,7 +8,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = "whatsapp_sdk"
-  spec.version = WhatsappSdk::Version::VERSION
+  spec.version = WhatsappSdk::VERSION
   spec.authors       = ["ignacio-chiazzo"]
   spec.email         = ["ignaciochiazzo@gmail.com"]
   spec.summary       = "Use the Ruby Whatsapp SDK to comunicate with Whatsapp API using the Cloud API"


### PR DESCRIPTION
There is a bug in the gem running on Linux. https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/44

I suspect it's related to Linux not _eager-loading_ the files in alphabetical order; Mac does it.