### PR TITLE
Add missing Content-Type headers

### DIFF
--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -22,10 +22,10 @@ module WhatsappSdk
           endpoint: String, full_url: T.nilable(String), http_method: String, params: T::Hash[T.untyped, T.untyped]
         ).returns(T::Hash[T.untyped, T.untyped])
       end
-      def send_request(endpoint: "", full_url: nil, http_method: "post", params: {})
+      def send_request(endpoint: "", full_url: nil, http_method: "post", params: {}, headers: {})
         url = full_url || API_CLIENT
 
-        response = T.unsafe(faraday(url)).public_send(http_method, endpoint, params)
+        response = T.unsafe(faraday(url)).public_send(http_method, endpoint, params, headers)
         Oj.load(response.body)
       end
 

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -19,7 +19,11 @@ module WhatsappSdk
 
       sig do
         params(
-          endpoint: String, full_url: T.nilable(String), http_method: String, params: T::Hash[T.untyped, T.untyped]
+          endpoint: String,
+          full_url: T.nilable(String),
+          http_method: String,
+          params: T::Hash[T.untyped, T.untyped],
+          headers: T::Hash[T.untyped, T.untyped]
         ).returns(T::Hash[T.untyped, T.untyped])
       end
       def send_request(endpoint: "", full_url: nil, http_method: "post", params: {}, headers: {})

--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -9,6 +9,8 @@ module WhatsappSdk
     class Messages < Request
       extend T::Sig
 
+      DEFAULT_HEADERS = T.let({ 'Content-Type' => 'application/json' }, Hash)
+
       class MissingArgumentError < StandardError
         extend T::Sig
 
@@ -40,7 +42,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -80,7 +83,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -120,7 +124,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -154,7 +159,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -194,7 +200,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -234,7 +241,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -268,7 +276,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -302,7 +311,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -338,7 +348,8 @@ module WhatsappSdk
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(
@@ -382,10 +393,13 @@ module WhatsappSdk
                                          else
                                            components.map(&:to_json)
                                          end
+        headers = {}
+        headers['Content-Type'] = 'application/json' if components_json
 
         response = send_request(
           endpoint: endpoint(sender_id),
-          params: params
+          params: params,
+          headers: DEFAULT_HEADERS
         )
 
         WhatsappSdk::Api::Response.new(

--- a/lib/whatsapp_sdk/api/request.rb
+++ b/lib/whatsapp_sdk/api/request.rb
@@ -14,9 +14,9 @@ module WhatsappSdk
         @client.download_file(url, path_to_file_name)
       end
 
-      def send_request(endpoint: nil, full_url: nil, http_method: "post", params: {})
+      def send_request(endpoint: nil, full_url: nil, http_method: "post", params: {}, headers: {})
         @client.send_request(
-          http_method: http_method, full_url: full_url, endpoint: endpoint, params: params
+          http_method: http_method, full_url: full_url, endpoint: endpoint, params: params, headers: headers
         )
       end
     end

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -51,7 +51,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "text",
             text: { body: "hola" }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_text(
@@ -91,7 +92,8 @@ module WhatsappSdk
               name: name,
               address: address
             }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_location(
@@ -130,7 +132,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "image",
             image: { link: image_link, caption: "Ignacio Chiazzo Profile" }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_image(
@@ -151,7 +154,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "image",
             image: { id: image_id, caption: "Ignacio Chiazzo Profile" }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_image(
@@ -189,7 +193,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "audio",
             audio: { link: audio_link }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_audio(
@@ -209,7 +214,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "audio",
             audio: { id: audio_id }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_audio(
@@ -246,7 +252,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "video",
             video: { link: video_link, caption: "Ignacio Chiazzo Profile" }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_video(
@@ -267,7 +274,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "video",
             video: { id: video_id, caption: "Ignacio Chiazzo Profile" }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_video(
@@ -305,7 +313,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "document",
             document: { link: document_link, caption: "Ignacio Chiazzo Profile" }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_document(
@@ -326,7 +335,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "document",
             document: { id: document_id, caption: "Ignacio Chiazzo Profile" }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_document(
@@ -364,7 +374,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: Resource::Media::Type::Sticker,
             sticker: { link: sticker_link }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_sticker(
@@ -384,7 +395,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: Resource::Media::Type::Sticker,
             sticker: { id: sticker_id }
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_sticker(
@@ -413,7 +425,8 @@ module WhatsappSdk
             recipient_type: "individual",
             type: "contacts",
             contacts: contacts.map(&:to_h)
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_contacts(
@@ -430,7 +443,8 @@ module WhatsappSdk
             messaging_product: "whatsapp",
             status: "read",
             message_id: "12345"
-          }
+          },
+          headers: { "Content-Type" => "application/json" }
         ).returns({ "success" => true })
 
         message_response = @messages_api.read_message(
@@ -601,7 +615,8 @@ module WhatsappSdk
                                                           }
                                                         ]
                                                       }
-                                                    }
+                                                    },
+                                                    headers: { "Content-Type" => "application/json" }
                                                   }).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_template(


### PR DESCRIPTION
Basically currently faraday sends body parameters as application/x-www-form-urlencoded

Which is annoying to work with using other popular test gems like WebMock

For example on 0.6.1
```
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: 
POST https://graph.facebook.com/v14.0/101230123123123/messages 
with body 'messaging_product=whatsapp&recipient_type=individual&template%5Bcomponents%5D%5B%5D%5Bparameters%5D%5B%5D%5Btext%5D=%7Btest%7D%3ABergstrom-Klein&template%5Bcomponents%5D%5B%5D%5Bparameters%5D%5B%5D%5Btype%5D=text&template%5Bcomponents%5D%5B%5D%5Btype%5D=header&template%5Bcomponents%5D%5B%5D%5Bparameters%5D%5B%5D%5Btext%5D=Jessi+Bosco&template%5Bcomponents%5D%5B%5D%5Bparameters%5D%5B%5D%5Btype%5D=text&template%5Bcomponents%5D%5B%5D%5Btype%5D=body&template%5Blanguage%5D%5Bcode%5D=en_GB&template%5Bname%5D=device_connected&to=7123456789&type=template' 
with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer whatappToken', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v2.5.2'}
```

After PR changes
```
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: 
POST https://graph.facebook.com/v14.0/101230123123123/messages 
with body '{:messaging_product=>"whatsapp", :recipient_type=>"individual", :to=>7123456789, :type=>"template", :template=>{:name=>"device_connected", :language=>{:code=>"en_GB"}, :components=>[{:type=>"header", :parameters=>[{:type=>"text", :text=>"{test}:Bartoletti-Cummings"}]}, {:type=>"body", :parameters=>[{:type=>"text", :text=>"Karoline Hyatt"}]}]}}' 
with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer whatappToken', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v2.5.2'}
```