### PR TITLE
Client updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group(:test) do
   gem('rubocop', require: false)
   gem('rubocop-minitest', require: false)
   gem('rubocop-performance', require: false)
+  gem('webmock')
 end
 
 group(:development) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     coderay (1.1.3)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.5.0)
     faraday (2.5.2)
       faraday-net_http (>= 2.0, < 3.1)
@@ -21,6 +25,7 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.0)
+    hashdiff (1.0.1)
     method_source (1.0.0)
     minitest (5.16.1)
     mocha (1.14.0)
@@ -35,6 +40,7 @@ GEM
       method_source (~> 1.0)
     pry-nav (1.0.0)
       pry (>= 0.9.10, < 0.15)
+    public_suffix (5.0.0)
     rainbow (3.1.1)
     rake (13.0.6)
     rbi (0.0.15)
@@ -66,6 +72,7 @@ GEM
       sorbet-static (= 0.5.10346)
     sorbet-runtime (0.5.10346)
     sorbet-static (0.5.10346-universal-darwin-21)
+    sorbet-static (0.5.10346-x86_64-linux)
     sorbet-static-and-runtime (0.5.10346)
       sorbet (= 0.5.10346)
       sorbet-runtime (= 0.5.10346)
@@ -88,6 +95,10 @@ GEM
     unparser (0.6.5)
       diff-lcs (~> 1.3)
       parser (>= 3.1.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)
@@ -98,6 +109,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.3)
@@ -116,6 +128,7 @@ DEPENDENCIES
   sorbet-runtime
   spoom
   tapioca
+  webmock
   whatsapp_sdk!
   zeitwerk (>= 2.6.0)
 

--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -393,8 +393,6 @@ module WhatsappSdk
                                          else
                                            components.map(&:to_json)
                                          end
-        headers = {}
-        headers['Content-Type'] = 'application/json' if components_json
 
         response = send_request(
           endpoint: endpoint(sender_id),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,4 @@ require 'mocha/minitest'
 require "pry"
 require "pry-nav"
 require "sorbet-runtime"
+require "webmock/minitest"

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'test_helper'
+require_relative '../../../lib/whatsapp_sdk/api/client'
+
+module WhatsappSdk
+  module Api
+    class ClientTest < Minitest::Test
+      def setup
+        @client = WhatsappSdk::Api::Client.new('test_token')
+      end
+
+      def test_send_request_post_with_success_response
+        stub_test_request(:post, body: { 'foo' => 'bar' },
+                                 headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
+
+        response_body = @client.send_request(endpoint: 'test',
+                                             http_method: 'post',
+                                             params: { 'foo' => 'bar' },
+                                             headers: {})
+        assert_equal({ 'success' => true }, response_body)
+      end
+
+      def test_send_request_post_json_content_with_success_response
+        stub_test_request(:post, body: { 'foo' => 'bar' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+        response_body = @client.send_request(endpoint: 'test',
+                                             http_method: 'post',
+                                             params: { 'foo' => 'bar' },
+                                             headers: { 'Content-Type' => 'application/json' })
+        assert_equal({ 'success' => true }, response_body)
+      end
+
+      def test_send_request_get_with_success_response
+        stub_test_request(:get)
+
+        response_body = @client.send_request(endpoint: 'test',
+                                             http_method: 'get')
+        assert_equal({ 'success' => true }, response_body)
+      end
+
+      def test_send_request_delete_with_success_response
+        stub_test_request(:delete, response_status: 204, response_body: "")
+
+        response_body = @client.send_request(endpoint: 'test',
+                                             http_method: 'delete')
+        assert_nil(response_body)
+      end
+
+      private
+
+      def stub_test_request(method_name, body: {}, headers: {}, response_status: 200, response_body: { success: true })
+        stub_request(method_name, "#{Client::API_CLIENT}test")
+          .with(body: body, headers: { 'Accept' => '*/*',
+                                       'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                                       'Authorization' => 'Bearer test_token' }.merge(headers))
+          .to_return(status: response_status, body: response_body.to_json, headers: {})
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Missing to_json when content-type is application/json
2. Handle 204 with empty body in response
3. Added client_test.rb with WebMock gem to mock and test outgoing requests

As for future:
medias.rb and phone_numbers.rb should be checked if they also should use content-type application/json