### PR TITLE
feat(Business Profile): Add Business Profile API

### DIFF
--- a/lib/whatsapp_sdk/api/business_profile.rb
+++ b/lib/whatsapp_sdk/api/business_profile.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+# typed: strict
+
+require_relative "request"
+require_relative "response"
+
+module WhatsappSdk
+  module Api
+    class BusinessProfile < Request
+      DEFAULT_FIELDS = 'about,address,description,email,profile_picture_url,websites,vertical'.freeze
+
+      # Get the details of business profile.
+      #
+      # @param phone_number_id [Integer] Phone Number Id.
+      # @return [WhatsappSdk::Api::Response] Response object.
+      sig { params(phone_number_id: Integer).returns(WhatsappSdk::Api::Response) }
+      def registered_numbers(phone_number_id)
+        response = send_request(
+          http_method: "get",
+          endpoint: "#{phone_number_id}/whatsapp_business_profile?fields=#{DEFAULT_FIELDS}"
+        )
+
+        WhatsappSdk::Api::Response.new(
+          response: response,
+          data_class_type: WhatsappSdk::Api::Responses::BusinessProfileDataResponse
+        )
+      end
+    end
+  end
+end

--- a/lib/whatsapp_sdk/api/business_profile.rb
+++ b/lib/whatsapp_sdk/api/business_profile.rb
@@ -14,7 +14,7 @@ module WhatsappSdk
       # @param phone_number_id [Integer] Phone Number Id.
       # @return [WhatsappSdk::Api::Response] Response object.
       sig { params(phone_number_id: Integer).returns(WhatsappSdk::Api::Response) }
-      def registered_numbers(phone_number_id)
+      def details(phone_number_id)
         response = send_request(
           http_method: "get",
           endpoint: "#{phone_number_id}/whatsapp_business_profile?fields=#{DEFAULT_FIELDS}"

--- a/lib/whatsapp_sdk/api/response.rb
+++ b/lib/whatsapp_sdk/api/response.rb
@@ -6,6 +6,7 @@ require_relative "responses/phone_number_data_response"
 require_relative "responses/phone_numbers_data_response"
 require_relative "responses/read_message_data_response"
 require_relative "responses/message_error_response"
+require_relative "responses/business_profile_data_response"
 
 module WhatsappSdk
   module Api

--- a/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
+++ b/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
@@ -27,18 +27,20 @@ module WhatsappSdk
 
         sig { params(response: T::Hash[T.untyped, T.untyped]).void }
         def initialize(response)
+          # TODO: Verify the other data
+
           @about = T.let(response["data"][0]["about"], String)
-          @address = T.let(response["data"][0]["address"], String)
-          @description = T.let(response["data"][0]["description"], String)
-          @email = T.let(response["data"][0]["email"], String)
+          # @address = T.let(response["data"][0]["address"], String)
+          # @description = T.let(response["data"][0]["description"], String)
+          # @email = T.let(respons e["data"][0]["email"], String)
           @messaging_product = T.let(response["data"][0]["messaging_product"], String)
-          @profile_picture_url = T.let(response["data"][0]["profile_picture_url"], String)
+          # @profile_picture_url = T.let(response["data"][0]["profile_picture_url"], String)
           super(response)
         end
 
         sig { override.params(response: T::Hash[T.untyped, T.untyped]).returns(T.nilable(BusinessProfileDataResponse)) }
         def self.build_from_response(response:)
-          return unless response["id"]
+          return nil if response['error']
 
           new(response)
         end

--- a/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
+++ b/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
@@ -27,14 +27,12 @@ module WhatsappSdk
 
         sig { params(response: T::Hash[T.untyped, T.untyped]).void }
         def initialize(response)
-          # TODO: Verify the other data
-
-          @about = T.let(response["data"][0]["about"], String)
-          # @address = T.let(response["data"][0]["address"], String)
-          # @description = T.let(response["data"][0]["description"], String)
-          # @email = T.let(respons e["data"][0]["email"], String)
-          @messaging_product = T.let(response["data"][0]["messaging_product"], String)
-          # @profile_picture_url = T.let(response["data"][0]["profile_picture_url"], String)
+          @about = T.let(response["data"][0]["about"], T.nilable(String))
+          @address = T.let(response["data"][0]["address"], T.nilable(String))
+          @description = T.let(response["data"][0]["description"], T.nilable(String))
+          @email = T.let(response["data"][0]["email"], T.nilable(String))
+          @messaging_product = T.let(response["data"][0]["messaging_product"], T.nilable(String))
+          @profile_picture_url = T.let(response["data"][0]["profile_picture_url"], T.nilable(String))
           super(response)
         end
 

--- a/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
+++ b/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+# typed: strict
+
+require_relative "data_response"
+
+module WhatsappSdk
+  module Api
+    module Responses
+      class BusinessProfileDataResponse < DataResponse
+        sig { returns(String) }
+        attr_accessor :about
+
+        sig { returns(String) }
+        attr_accessor :address
+
+        sig { returns(String) }
+        attr_accessor :description
+
+        sig { returns(String) }
+        attr_accessor :email
+
+        sig { returns(String) }
+        attr_accessor :messaging_product
+
+        sig { returns(String) }
+        attr_accessor :profile_picture_url
+
+        sig { params(response: T::Hash[T.untyped, T.untyped]).void }
+        def initialize(response)
+          @about = T.let(response["data"][0]["about"], String)
+          @address = T.let(response["data"][0]["address"], String)
+          @description = T.let(response["data"][0]["description"], String)
+          @email = T.let(response["data"][0]["email"], String)
+          @messaging_product = T.let(response["data"][0]["messaging_product"], String)
+          @profile_picture_url = T.let(response["data"][0]["profile_picture_url"], String)
+          super(response)
+        end
+
+        sig { override.params(response: T::Hash[T.untyped, T.untyped]).returns(T.nilable(BusinessProfileDataResponse)) }
+        def self.build_from_response(response:)
+          return unless response["id"]
+
+          new(response)
+        end
+      end
+    end
+  end
+end

--- a/test/whatsapp_sdk/api/business_profile_test.rb
+++ b/test/whatsapp_sdk/api/business_profile_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+# typed: true
+
+require "test_helper"
+require_relative '../../../lib/whatsapp_sdk/api/business_profile'
+require_relative '../../../lib/whatsapp_sdk/resource/contact_response'
+require_relative '../../../lib/whatsapp_sdk/api/client'
+
+module WhatsappSdk
+  module Api
+    class BusinessProfileTest < Minitest::Test
+      def setup
+        client = WhatsappSdk::Api::Client.new("test_token")
+        @business_profile_api = WhatsappSdk::Api::BusinessProfile.new(client)
+      end
+
+      def test_details_handles_error_response
+        mocked_error_response = mock_error_response
+        response = @business_profile_api.details(123_123)
+        assert_mock_error_response(mocked_error_response, response)
+      end
+
+      def test_details_with_success_response
+        mock_business_profile_response(valid_details_response)
+        response = @business_profile_api.details(123_123)
+        assert_business_details_mock_response(valid_detail_response, response)
+        assert_predicate(response, :ok?)
+      end
+
+      private
+
+      def mock_error_response
+        error_response = {
+          "error" => {
+            "message" => "Unsupported post request.",
+            "type" => "GraphMethodException",
+            "code" => 100,
+            "error_subcode" => 33,
+            "fbtrace_id" => "Au12W6oW_Np1IyF4v5YwAiU"
+          }
+        }
+        @business_profile_api.stubs(:send_request).returns(error_response)
+        error_response
+      end
+
+      def mock_business_profile_response(response)
+        @business_profile_api.stubs(:send_request).returns(response)
+        response
+      end
+
+      def valid_details_response(
+        about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp"
+      )
+        {
+          "data" => [
+            valid_detail_response(about: about, messaging_product: messaging_product)
+          ]
+        }
+      end
+
+      def valid_detail_response(
+        about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp"
+      )
+        {
+          "about" => about,
+          "messaging_product" => messaging_product
+        }
+      end
+
+      def assert_mock_error_response(mocked_error, response)
+        refute_predicate(response, :ok?)
+        assert_nil(response.data)
+        error = response.error
+        assert_equal(WhatsappSdk::Api::Responses::MessageErrorResponse, error.class)
+        assert_equal(mocked_error["error"]["code"], error.code)
+        assert_equal(mocked_error["error"]["error_subcode"], error.subcode)
+        assert_equal(mocked_error["error"]["message"], error.message)
+        assert_equal(mocked_error["error"]["error_subcode"], error.subcode)
+        assert_equal(mocked_error["error"]["fbtrace_id"], error.fbtrace_id)
+      end
+
+      def assert_business_details_mock_response(expected_business_profile, response)
+        assert_equal(WhatsappSdk::Api::Response, response.class)
+        assert_nil(response.error)
+        assert_predicate(response, :ok?)
+        # assert_equal(response.data.about, 'Hey there! I am using WhatsApp.')
+        # assert_equal(response.data.messaging_product, 'whatsapp')
+      end
+    end
+  end
+end

--- a/test/whatsapp_sdk/api/business_profile_test.rb
+++ b/test/whatsapp_sdk/api/business_profile_test.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 # typed: true
 
-require "test_helper"
 require_relative '../../../lib/whatsapp_sdk/api/business_profile'
-require_relative '../../../lib/whatsapp_sdk/resource/contact_response'
 require_relative '../../../lib/whatsapp_sdk/api/client'
 
 module WhatsappSdk
@@ -83,8 +81,8 @@ module WhatsappSdk
         assert_equal(WhatsappSdk::Api::Response, response.class)
         assert_nil(response.error)
         assert_predicate(response, :ok?)
-        # assert_equal(response.data.about, 'Hey there! I am using WhatsApp.')
-        # assert_equal(response.data.messaging_product, 'whatsapp')
+        assert_equal(response.data.about, 'Hey there! I am using WhatsApp.')
+        assert_equal(response.data.messaging_product, 'whatsapp')
       end
     end
   end


### PR DESCRIPTION
# Description

Issue Link: #52 
Add Business profile API

- [x] Create a file business_profile.rb in lib/whatsapp_sdk/api/business_profile.rb, similar to https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/blob/main/lib/whatsapp_sdk/api/phone_numbers.rb.
- [x] Add a test file.
- [x] Add get method
- [ ] Add update method (TODO)

Documentation: https://developers.facebook.com/docs/whatsapp/cloud-api/reference/business-profiles