### PR TITLE
feat(Business Profile): Business Profile Update API 

### DIFF
--- a/lib/whatsapp_sdk/api/business_profile.rb
+++ b/lib/whatsapp_sdk/api/business_profile.rb
@@ -31,6 +31,11 @@ module WhatsappSdk
       # @param phone_number_id [Integer] Phone Number Id.
       # @param params [Hash] Params to update.
       # @return [WhatsappSdk::Api::Response] Response object.
+      sig do
+        params(
+          phone_number_id: Integer, params: T::Hash[T.untyped, T.untyped]
+        ).returns(WhatsappSdk::Api::Response)
+      end
       def update(phone_number_id:, params:)
         # this is a required field
         params.merge!({ messaging_product: 'whatsapp' })

--- a/lib/whatsapp_sdk/api/business_profile.rb
+++ b/lib/whatsapp_sdk/api/business_profile.rb
@@ -25,6 +25,27 @@ module WhatsappSdk
           data_class_type: WhatsappSdk::Api::Responses::BusinessProfileDataResponse
         )
       end
+
+      # Update the details of business profile.
+      #
+      # @param phone_number_id [Integer] Phone Number Id.
+      # @param params [Hash] Params to update.
+      # @return [WhatsappSdk::Api::Response] Response object.
+      def update(phone_number_id:, params:)
+        # this is a required field
+        params.merge!({ messaging_product: 'whatsapp' })
+
+        response = send_request(
+          http_method: "post",
+          endpoint: "#{phone_number_id}/whatsapp_business_profile",
+          params: params
+        )
+
+        WhatsappSdk::Api::Response.new(
+          response: response,
+          data_class_type: WhatsappSdk::Api::Responses::SuccessResponse
+        )
+      end
     end
   end
 end

--- a/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
+++ b/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
@@ -28,6 +28,9 @@ module WhatsappSdk
         sig { returns(T.nilable(String)) }
         attr_accessor :vertical
 
+        sig { returns(T::Array[String]) }
+        attr_accessor :websites
+
         sig { params(response: T::Hash[T.untyped, T.untyped]).void }
         def initialize(response)
           @about = T.let(response["data"][0]["about"], T.nilable(String))
@@ -37,6 +40,7 @@ module WhatsappSdk
           @messaging_product = T.let(response["data"][0]["messaging_product"], T.nilable(String))
           @profile_picture_url = T.let(response["data"][0]["profile_picture_url"], T.nilable(String))
           @vertical = T.let(response["data"][0]["vertical"], T.nilable(String))
+          @websites = T.let(response["data"][0]["websites"], T::Array[String])
           super(response)
         end
 

--- a/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
+++ b/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
@@ -7,25 +7,25 @@ module WhatsappSdk
   module Api
     module Responses
       class BusinessProfileDataResponse < DataResponse
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_accessor :about
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_accessor :address
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_accessor :description
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_accessor :email
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_accessor :messaging_product
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_accessor :profile_picture_url
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_accessor :vertical
 
         sig { params(response: T::Hash[T.untyped, T.untyped]).void }

--- a/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
+++ b/lib/whatsapp_sdk/api/responses/business_profile_data_response.rb
@@ -25,6 +25,9 @@ module WhatsappSdk
         sig { returns(String) }
         attr_accessor :profile_picture_url
 
+        sig { returns(String) }
+        attr_accessor :vertical
+
         sig { params(response: T::Hash[T.untyped, T.untyped]).void }
         def initialize(response)
           @about = T.let(response["data"][0]["about"], T.nilable(String))
@@ -33,6 +36,7 @@ module WhatsappSdk
           @email = T.let(response["data"][0]["email"], T.nilable(String))
           @messaging_product = T.let(response["data"][0]["messaging_product"], T.nilable(String))
           @profile_picture_url = T.let(response["data"][0]["profile_picture_url"], T.nilable(String))
+          @vertical = T.let(response["data"][0]["vertical"], T.nilable(String))
           super(response)
         end
 

--- a/test/whatsapp_sdk/api/business_profile_test.rb
+++ b/test/whatsapp_sdk/api/business_profile_test.rb
@@ -31,6 +31,13 @@ module WhatsappSdk
         assert_mock_error_response(mocked_error_response, response)
       end
 
+      def test_update_with_success_response
+        mock_business_profile_response(valid_update_response)
+        response = @business_profile_api.update(phone_number_id: 123_123, params: valid_detail_response)
+        assert_update_details_mock_response(valid_update_response, response)
+        assert_predicate(response, :ok?)
+      end
+
       private
 
       def mock_error_response
@@ -84,6 +91,12 @@ module WhatsappSdk
         }
       end
 
+      def valid_update_response
+        {
+          "success" => true
+        }
+      end
+
       def assert_mock_error_response(mocked_error, response)
         refute_predicate(response, :ok?)
         assert_nil(response.data)
@@ -98,6 +111,7 @@ module WhatsappSdk
 
       def assert_business_details_mock_response(expected_business_profile, response)
         assert_equal(WhatsappSdk::Api::Response, response.class)
+        assert_equal(WhatsappSdk::Api::Responses::BusinessProfileDataResponse, response.data.class)
         assert_nil(response.error)
         assert_predicate(response, :ok?)
         assert_equal(expected_business_profile["about"], response.data.about)
@@ -107,6 +121,14 @@ module WhatsappSdk
         assert_equal(expected_business_profile["email"], response.data.email)
         assert_equal(expected_business_profile["websites"], response.data.websites)
         assert_equal(expected_business_profile["vertical"], response.data.vertical)
+      end
+
+      def assert_update_details_mock_response(expected_response, response)
+        assert_equal(WhatsappSdk::Api::Response, response.class)
+        assert_equal(WhatsappSdk::Api::Responses::SuccessResponse, response.data.class)
+        assert_nil(response.error)
+        assert_predicate(response, :ok?)
+        assert_equal(expected_response["success"], response.data.success?)
       end
     end
   end

--- a/test/whatsapp_sdk/api/business_profile_test.rb
+++ b/test/whatsapp_sdk/api/business_profile_test.rb
@@ -25,6 +25,12 @@ module WhatsappSdk
         assert_predicate(response, :ok?)
       end
 
+      def test_update_handles_error_response
+        mocked_error_response = mock_error_response
+        response = @business_profile_api.update(phone_number_id: 123_123, params: valid_detail_response)
+        assert_mock_error_response(mocked_error_response, response)
+      end
+
       private
 
       def mock_error_response
@@ -46,6 +52,7 @@ module WhatsappSdk
         response
       end
 
+      # this is a hash of a valid business profile response from API
       def valid_details_response(
         about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp",
         address: "123, Main Street, New York, NY, 10001", description: "This is a description",
@@ -60,6 +67,7 @@ module WhatsappSdk
         }
       end
 
+      # this is a hash of a valid business profile
       def valid_detail_response(
         about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp",
         address: "123, Main Street, New York, NY, 10001", description: "This is a description",

--- a/test/whatsapp_sdk/api/business_profile_test.rb
+++ b/test/whatsapp_sdk/api/business_profile_test.rb
@@ -47,21 +47,32 @@ module WhatsappSdk
       end
 
       def valid_details_response(
-        about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp"
+        about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp",
+        address: "123, Main Street, New York, NY, 10001", description: "This is a description",
+        email: "testing@gmail.com", websites: ["https://www.google.com"], vertical: "EDU"
       )
         {
           "data" => [
-            valid_detail_response(about: about, messaging_product: messaging_product)
+            valid_detail_response(about: about, messaging_product: messaging_product,
+                                  address: address, description: description, email: email,
+                                  websites: websites, vertical: vertical)
           ]
         }
       end
 
       def valid_detail_response(
-        about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp"
+        about: "Hey there! I am using WhatsApp.", messaging_product: "whatsapp",
+        address: "123, Main Street, New York, NY, 10001", description: "This is a description",
+        email: "testing@gmail.com", websites: ["https://www.google.com"], vertical: "EDU"
       )
         {
           "about" => about,
-          "messaging_product" => messaging_product
+          "messaging_product" => messaging_product,
+          "address" => address,
+          "description" => description,
+          "email" => email,
+          "websites" => websites,
+          "vertical" => vertical
         }
       end
 
@@ -83,6 +94,11 @@ module WhatsappSdk
         assert_predicate(response, :ok?)
         assert_equal(expected_business_profile["about"], response.data.about)
         assert_equal(expected_business_profile["messaging_product"], response.data.messaging_product)
+        assert_equal(expected_business_profile["address"], response.data.address)
+        assert_equal(expected_business_profile["description"], response.data.description)
+        assert_equal(expected_business_profile["email"], response.data.email)
+        assert_equal(expected_business_profile["websites"], response.data.websites)
+        assert_equal(expected_business_profile["vertical"], response.data.vertical)
       end
     end
   end


### PR DESCRIPTION
# Description

Issue Link: #52 and #55 
Add Business profile API

- [x] Fix sorbet type checks in the business profile data response
- [x] Add `websites` and `vertical` to the get business profile data response
- [x]  Add tests for receiving business profiles.
- [x] Add update method for business profile
- [x] Add tests for update method for business profile

Documentation: https://developers.facebook.com/docs/whatsapp/cloud-api/reference/business-profiles