### PR TITLE
feat: Adds send_reaction method to messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ messages_api.read_message(sender_id: 1234, message_id: "wamid.HBgLMTM0M123456789
 
 Note: To get the `message_id` you can set up [Webhooks](https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components) that will listen and fire an event when a message is received.
 
+**Send a reaction to message**
+To send a reaction to a message, you need to obtain the mssage id and look for the emoji's unicode you want to use.
+
+```ruby
+messages_api.send_reaction(sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "\u{1f550}")
+
+messages_api.send_reaction(sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "⛄️")
+```
 
 **Send a location message**
 
@@ -311,13 +319,6 @@ Alernative, you could pass a plain json like this:
 @messages_api.send_template(sender_id: 12_345, recipient_number: 12345678, name: "hello_world", language: "en_US", components_json: [{...}])
 ```
 </details>
-
-**Send a reaction to message**
-To send a reaction to a message, you need to obtain the mssage id and look for the emoji's unicode you want to use.
-
-```ruby
-messages_api.send_reaction(sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "\\uD83D\\uDE00")
-```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <a href="https://codeclimate.com/github/ignacio-chiazzo/ruby_whatsapp_sdk/maintainability"><img src="https://api.codeclimate.com/v1/badges/169cce95450272e4ad7d/maintainability" /></a>
 
 The SDK provides a set of operations and classes to use the Whatsapp API.
-Send stickers, messages, audio, videos, and locations or just ask for the phone numbers through this library in a few steps!
+Send stickers, messages, audio, videos, locations, react to messages or just ask for the phone numbers through this library in a few steps!
 
 
 ## Demo
@@ -311,6 +311,13 @@ Alernative, you could pass a plain json like this:
 @messages_api.send_template(sender_id: 12_345, recipient_number: 12345678, name: "hello_world", language: "en_US", components_json: [{...}])
 ```
 </details>
+
+**Send a reaction to message**
+To send a reaction to a message, you need to obtain the mssage id and look for the emoji's unicode you want to use.
+
+```ruby
+messages_api.send_reaction(sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "\\uD83D\\uDE00")
+```
 
 ## Examples
 

--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -406,6 +406,42 @@ module WhatsappSdk
         )
       end
 
+      # Send reaction
+      #
+      # @param sender_id [Integer] Sender' phone number.
+      # @param recipient_number [Integer] Recipient' Phone number.
+      # @param message_id [String] the id of the message to reaction.
+      # @param emoji [String] unicode of the emoji to send.
+      # @return [WhatsappSdk::Api::Response] Response object.
+      sig do
+        params(
+          sender_id: Integer, recipient_number: Integer, message_id: String, emoji: String
+        ).returns(WhatsappSdk::Api::Response)
+      end
+      def send_reaction(sender_id:, recipient_number:, message_id:, emoji:)
+        params = {
+          messaging_product: "whatsapp",
+          recipient_type: "individual",
+          to: recipient_number,
+          type: "reaction",
+          reaction: {
+            message_id: message_id,
+            emoji: emoji
+          }
+        }
+
+        response = send_request(
+          endpoint: endpoint(sender_id),
+          params: params,
+          headers: DEFAULT_HEADERS
+        )
+
+        WhatsappSdk::Api::Response.new(
+          response: response,
+          data_class_type: WhatsappSdk::Api::Responses::MessageDataResponse
+        )
+      end
+
       private
 
       sig { params(sender_id: Integer).returns(String) }

--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -415,7 +415,7 @@ module WhatsappSdk
       # @return [WhatsappSdk::Api::Response] Response object.
       sig do
         params(
-          sender_id: Integer, recipient_number: Integer, message_id: String, emoji: String
+          sender_id: Integer, recipient_number: Integer, message_id: String, emoji: T.any(String, Integer)
         ).returns(WhatsappSdk::Api::Response)
       end
       def send_reaction(sender_id:, recipient_number:, message_id:, emoji:)

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -629,6 +629,38 @@ module WhatsappSdk
       end
       # rubocop:enable Metrics/MethodLength
 
+      def test_send_reaction_with_success_response
+        mock_response(valid_contacts, valid_messages)
+        message_response = @messages_api.send_reaction(
+          sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "\\uD83D\\uDE00" 
+        )
+        assert_mock_response(valid_contacts, valid_messages, message_response)
+        assert_predicate(message_response, :ok?)
+      end
+
+      def test_send_reaction_with_a_valid_response
+        @messages_api.expects(:send_request).with(
+          endpoint: "123123/messages",
+          params: {
+            messaging_product: "whatsapp",
+            to: 56_789,
+            recipient_type: "individual",
+            type: "reaction",
+            reaction: {
+              message_id: "12345",
+              emoji: "\\uD83D\\uDE00" 
+            }
+          },
+          headers: { "Content-Type" => "application/json" }
+        ).returns(valid_response(valid_contacts, valid_messages))
+
+        message_response = @messages_api.send_reaction(
+          sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "\\uD83D\\uDE00" 
+        )
+        assert_mock_response(valid_contacts, valid_messages, message_response)
+        assert_predicate(message_response, :ok?)
+      end
+
       private
 
       def mock_error_response


### PR DESCRIPTION
This commit adds send_reaction method to messages, as indicated in 

Description
Issue Link: https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/51 
Add Send reaction method

- [x] Add send_reaction method to messages
- [x] Add support to arm64-darwin-21
 
Documentation: https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages/?locale=en_US#reaction-messages