### PR TITLE
Implement Register API

### DIFF
--- a/lib/whatsapp_sdk/api/phone_numbers.rb
+++ b/lib/whatsapp_sdk/api/phone_numbers.rb
@@ -40,6 +40,52 @@ module WhatsappSdk
           data_class_type: WhatsappSdk::Api::Responses::PhoneNumberDataResponse
         )
       end
+
+      # Register a phone number.
+      #
+      # @param phone_number_id [Integer] The registered number we want to retrieve.
+      # @param pin [Integer] Pin of 6 digits.
+      # @return [WhatsappSdk::Api::Response] Response object.
+      sig do
+        params(
+          phone_number_id: Integer,
+          pin: Integer
+        ).returns(WhatsappSdk::Api::Response)
+      end
+      def register_number(phone_number_id, pin)
+        response = send_request(
+          http_method: "post",
+          endpoint: "#{phone_number_id}/register",
+          params: { messaging_product: 'whatsapp', pin: pin }
+        )
+
+        WhatsappSdk::Api::Response.new(
+          response: response,
+          data_class_type: WhatsappSdk::Api::Responses::PhoneNumberDataResponse
+        )
+      end
+
+      # Deregister a phone number.
+      #
+      # @param phone_number_id [Integer] The registered number we want to retrieve.
+      # @return [WhatsappSdk::Api::Response] Response object.
+      sig do
+        params(
+          phone_number_id: Integer
+        ).returns(WhatsappSdk::Api::Response)
+      end
+      def deregister_number(phone_number_id)
+        response = send_request(
+          http_method: "post",
+          endpoint: "#{phone_number_id}/deregister",
+          params: {}
+        )
+
+        WhatsappSdk::Api::Response.new(
+          response: response,
+          data_class_type: WhatsappSdk::Api::Responses::PhoneNumberDataResponse
+        )
+      end
     end
   end
 end

--- a/test/whatsapp/api/phone_numbers_test.rb
+++ b/test/whatsapp/api/phone_numbers_test.rb
@@ -62,6 +62,64 @@ module WhatsappSdk
         assert_predicate(response, :ok?)
       end
 
+      def test_register_number_handles_error_response
+        mocked_error_response = invalid_register_number_response
+        response = @phone_numbers_api.register_number(123_123, 123)
+        assert_mock_error_response(mocked_error_response, response)
+      end
+
+      def test_register_number_with_success_response
+        mock_phone_numbers_response({ "success" => true })
+        response = @phone_numbers_api.register_number(123_123, 123_456)
+
+        assert_equal(WhatsappSdk::Api::Response, response.class)
+        assert_nil(response.error)
+        assert_predicate(response, :ok?)
+      end
+
+      def test_register_number_sends_valid_params
+        @phone_numbers_api.expects(:send_request).with(
+          http_method: "post",
+          endpoint: "123123/register",
+          params: {
+            messaging_product: 'whatsapp', pin: 123456
+          }
+        ).returns({ "success" => true })
+
+        response = @phone_numbers_api.register_number(123_123, 123_456)
+        assert_equal(WhatsappSdk::Api::Response, response.class)
+        assert_nil(response.error)
+        assert_predicate(response, :ok?)
+      end
+
+      def test_deregister_number_handles_error_response
+        mocked_error_response = invalid_deregister_number_response
+        response = @phone_numbers_api.deregister_number(123_123)
+        assert_mock_error_response(mocked_error_response, response)
+      end
+
+      def test_deregister_number_with_success_response
+        mock_phone_numbers_response({ "success" => true })
+        response = @phone_numbers_api.deregister_number(123_123)
+
+        assert_equal(WhatsappSdk::Api::Response, response.class)
+        assert_nil(response.error)
+        assert_predicate(response, :ok?)
+      end
+
+      def test_deregister_number_sends_valid_params
+        @phone_numbers_api.expects(:send_request).with(
+          http_method: "post",
+          endpoint: "123123/deregister",
+          params: {}
+        ).returns({ "success" => true })
+
+        response = @phone_numbers_api.deregister_number(123_123)
+        assert_equal(WhatsappSdk::Api::Response, response.class)
+        assert_nil(response.error)
+        assert_predicate(response, :ok?)
+      end
+
       private
 
       def mock_error_response
@@ -114,6 +172,38 @@ module WhatsappSdk
             }
           }
         }
+      end
+
+      def invalid_register_number_response
+        error_response = {
+          "error" =>
+            {
+              "message" => "(#100) Param pin must be 6 characters long.",
+              "type" => "OAuthException",
+              "code" => 100,
+              "fbtrace_id" => "AVU2ojfLmjKZSKbkWqjA_Uc"
+            }
+        }
+
+        @phone_numbers_api.stubs(:send_request).returns(error_response)
+        error_response
+      end
+
+      def invalid_deregister_number_response
+        error_response = {
+          "error" =>
+            {
+              "message" => "(#100) Invalid parameter",
+              "type" => "OAuthException",
+              "code" => 100,
+              "error_data" => "Phone number not registered on the Whatsapp Business Platform.",
+              "error_subcode" => 133010,
+              "fbtrace_id" => "A2iaN-Erjaze-0ABvoagZFI"
+            }
+        }
+
+        @phone_numbers_api.stubs(:send_request).returns(error_response)
+        error_response
       end
 
       def assert_mock_error_response(mocked_error, response)


### PR DESCRIPTION
# Summary

Implement Registration WhatsApp API 

## What is the change?

### Before

- Missing `register` and ` deregister` endpoints 

### Changes

- lib/whatsapp_sdk/api/phone_numbers.rb
- lib/whatsapp_sdk/version.rb

### After

- Was included `register` and ` deregister` endpoints to register phone number.

## Checklist

- [x] **Unit tests:** Run `rake test`
- [x] **Sorbet Typecheck:** run `srb tc`
- [x] **Linters:** `bundle exec rubocop`

## Related 

[ISSUE-64](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/64)