### PR TITLE
Make sorbet a development dependency

### DIFF
--- a/whatsapp_sdk.gemspec
+++ b/whatsapp_sdk.gemspec
@@ -43,8 +43,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
-  spec.add_dependency('sorbet')
-  spec.add_dependency('sorbet-runtime')
+  spec.add_development_dependency 'sorbet'
+  spec.add_development_dependency 'sorbet-runtime'
 
   spec.add_dependency("faraday", ">= 2.3.0")
   spec.add_dependency("faraday-multipart", "~> 1.0.4")


### PR DESCRIPTION
Sorbet is causing install issues for me, and it's not actually needed to run the code.