### PR TITLE
Release 0.7.2 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased 
 
+# v 0.7.2
 - Added new fields to phone numbers API. @ignacio-chiazzo [#73](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/73)
 - Upgraded API version to v16. @ignacio-chiazzo [#73](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/73)
 - Make sorbet-runtime a runtime dependency. @ignacio-chiazzo [#70](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/70)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.7.1)
+    whatsapp_sdk (0.7.2)
       faraday (~> 2.3.0)
       faraday-multipart (~> 1.0.4)
       oj (~> 3.13.13)

--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module WhatsappSdk
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/test/whatsapp/version_test.rb
+++ b/test/whatsapp/version_test.rb
@@ -6,6 +6,6 @@ require_relative '../../lib/whatsapp_sdk/version'
 
 class VersionTest < Minitest::Test
   def test_that_it_has_a_version_number
-    assert_equal("0.7.1", WhatsappSdk::VERSION)
+    assert_equal("0.7.2", WhatsappSdk::VERSION)
   end
 end


### PR DESCRIPTION
- Added new fields to phone numbers API. @ignacio-chiazzo [#73](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/73)
- Upgraded API version to v16. @ignacio-chiazzo [#73](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/73)
- Make sorbet-runtime a runtime dependency. @ignacio-chiazzo [#70](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/70)