### PR TITLE
Remove OJ as a dependency in favour of Ruby Json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased 
-- Send interactive Reply Buttons Message @alienware https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/79
+- Support JRuby @ignacio-chiazzo [#83](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/83)
+- Send interactive Reply Buttons Message @alienware [#79](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/79)
 
 # v 0.7.3
 - Added the ability to reply messages. @alienware [#77](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/77)

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem("faraday")
 gem("faraday-multipart")
-gem("oj")
 gem("rake", ">= 12.3.3")
 gem('sorbet-runtime')
 gem("zeitwerk", ">= 2.6.0")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     whatsapp_sdk (0.7.3)
       faraday (~> 2.3.0)
       faraday-multipart (~> 1.0.4)
-      oj (~> 3.13.13)
       sorbet-runtime (~> 0.5.1)
       zeitwerk (~> 2.6.0)
 
@@ -30,7 +29,6 @@ GEM
     mocha (1.14.0)
     multipart-post (2.2.3)
     netrc (0.11.0)
-    oj (3.13.14)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -119,7 +117,6 @@ DEPENDENCIES
   faraday-multipart
   minitest (~> 5.0)
   mocha
-  oj
   pry
   pry-nav
   rake (>= 12.3.3)

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -29,7 +29,7 @@ module WhatsappSdk
         faraday_request = T.unsafe(faraday(url))
 
         response = faraday_request.public_send(http_method, endpoint, request_params(params, headers), headers)
-        
+
         return nil if response.body == ""
 
         JSON.parse(response.body)

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -3,7 +3,6 @@
 
 require "faraday"
 require "faraday/multipart"
-require "oj"
 
 module WhatsappSdk
   module Api
@@ -30,8 +29,10 @@ module WhatsappSdk
         faraday_request = T.unsafe(faraday(url))
 
         response = faraday_request.public_send(http_method, endpoint, request_params(params, headers), headers)
+        
+        return nil if response.body == ""
 
-        Oj.load(response.body)
+        JSON.parse(response.body)
       end
 
       sig { params(url: String, path_to_file_name: T.nilable(String)).returns(Net::HTTPResponse) }

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -44,8 +44,7 @@ module WhatsappSdk
       def test_send_request_delete_with_success_response
         stub_test_request(:delete, response_status: 204, response_body: "")
 
-        response_body = @client.send_request(endpoint: 'test',
-                                             http_method: 'delete')
+        response_body = @client.send_request(endpoint: 'test', http_method: 'delete')
         assert_nil(response_body)
       end
 

--- a/whatsapp_sdk.gemspec
+++ b/whatsapp_sdk.gemspec
@@ -49,7 +49,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("faraday", "~> 2.3.0")
   spec.add_dependency("faraday-multipart", "~> 1.0.4")
-  spec.add_dependency("oj", "~> 3.13.13")
   spec.add_dependency("zeitwerk", "~> 2.6.0")
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Support JRuby by removing OJ gem in favour of Json ruby standard.

OJ gem has removed support for JRuby https://github.com/ohler55/oj/blob/b6b8193d8ba0e6c5fe2664037428c39b0e7e0764/pages/Compatibility.md?plain=1#L6

cc @jimtng 