### PR TITLE
Fix media audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased 
+
+# v 0.9.0
+- Use binary mode to download files @ignacio-chiazzo [#88](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/87)
 - Added support for downloading media by specifying the type @ignacio-chiazzo [#87](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/87)
 
 # v 0.8.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.8.0)
+    whatsapp_sdk (0.9.0)
       faraday (~> 2.3.0)
       faraday-multipart (~> 1.0.4)
       sorbet-runtime (~> 0.5.1)

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -50,7 +50,7 @@ module WhatsappSdk
           http.request(request)
         end
 
-        File.write(file_path, response.body) if response.code == "200" && file_path
+        File.write(file_path, response.body, mode: 'wb') if response.code == "200" && file_path
 
         response
       end

--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module WhatsappSdk
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/test/whatsapp/version_test.rb
+++ b/test/whatsapp/version_test.rb
@@ -6,6 +6,6 @@ require_relative '../../lib/whatsapp_sdk/version'
 
 class VersionTest < Minitest::Test
   def test_that_it_has_a_version_number
-    assert_equal("0.8.0", WhatsappSdk::VERSION)
+    assert_equal("0.9.0", WhatsappSdk::VERSION)
   end
 end


### PR DESCRIPTION
A few users reported an error when downloading assets like pdfs, audios and movies:

`Encoding::UndefinedConversionError ("\x80" from ASCII-8BIT to UTF-8):`

The problem was on the `File.write(file_path, response.body)` which was not considering binary. The fix was to specify the format mode `mode: 'wb'`. I have also considered using libraries.