### PR TITLE
Invalidate unsupported  and invalid media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased 
 
+# v 0.9.1
+- Invalidate unsupported and invalid media types @ignacio-chiazzo [#89](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/89)
+
 # v 0.9.0
 - Use binary mode to download files @ignacio-chiazzo [#88](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/87)
 - Added support for downloading media by specifying the type @ignacio-chiazzo [#87](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/87)

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -36,14 +36,14 @@ module WhatsappSdk
       end
 
       sig do
-        params(url: String, content_header: String, file_path: T.nilable(String))
+        params(url: String, content_type_header: String, file_path: T.nilable(String))
           .returns(Net::HTTPResponse)
       end
-      def download_file(url:, content_header:, file_path: nil)
+      def download_file(url:, content_type_header:, file_path: nil)
         uri = URI.parse(url)
         request = Net::HTTP::Get.new(uri)
         request["Authorization"] = "Bearer #{@access_token}"
-        request.content_type = content_header
+        request.content_type = content_type_header
         req_options = { use_ssl: uri.scheme == "https" }
 
         response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|

--- a/lib/whatsapp_sdk/api/request.rb
+++ b/lib/whatsapp_sdk/api/request.rb
@@ -10,8 +10,8 @@ module WhatsappSdk
         @client = client
       end
 
-      def download_file(url:, content_header:, file_path: nil)
-        @client.download_file(url: url, content_header: content_header, file_path: file_path)
+      def download_file(url:, content_type_header:, file_path: nil)
+        @client.download_file(url: url, content_type_header: content_type_header, file_path: file_path)
       end
 
       def send_request(endpoint: nil, full_url: nil, http_method: "post", params: {}, headers: {})

--- a/lib/whatsapp_sdk/resource/media_types.rb
+++ b/lib/whatsapp_sdk/resource/media_types.rb
@@ -1,0 +1,30 @@
+# typed: strict
+# frozen_string_literal: true
+
+module WhatsappSdk
+  module Resource
+    class MediaTypes
+      extend T::Sig
+
+      # The media types supported by Whatsapp. The list contains all the types defined in the Whatsapp API
+      # documentation: https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#supported-media-types
+      #
+      # The media type is used as a content-type header when downloading the file with MediasApi#download_file.
+      # The content-type header matches with the media type using Internet Assigned Numbers Authority (IANA).
+      # Media type list defined by IANA https://www.iana.org/assignments/media-types/media-types.xhtml
+      #
+
+      AUDIO_TYPES = %w[audio/aac audio/mp4 audio/mpeg audio/amr audio/ogg].freeze
+      DOCUMENT_TYPES = %w[
+        text/plain application/pdf application/vnd.ms-powerpoint application/msword application/vnd.ms-excel
+        application/vnd.openxmlformats-officedocument.wordprocessingml.document
+        application/vnd.openxmlformats-officedocument.presentationml.presentation
+        application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+      ].freeze
+      IMAGE_TYPES = %w[image/jpeg image/png].freeze
+      VIDEO_TYPES = %w[video/mp4 video/3gp].freeze
+
+      SUPPORTED_MEDIA_TYPES = [AUDIO_TYPES + DOCUMENT_TYPES + IMAGE_TYPES + VIDEO_TYPES].flatten.freeze
+    end
+  end
+end


### PR DESCRIPTION
### Problem
Some consumers reported the error `Encoding::UndefinedConversionError ("\x80" from ASCII-8BIT to UTF-8)` when downloading media files. 

The reasons were:
  1) The library file wasn't using Binary format when writing the file. Fixed by https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/88
  2) Consumers needed to set the correct media type. 

### Supported Media Types
The media types supported by Whatsapp are: 
```
Audio Types: 
        audio/aac, audio/mp4, audio/mpeg, audio/amr, audio/ogg
Document Types: 
        text/plain application/pdf application/vnd.ms-powerpoint 
        application/msword application/vnd.ms-excel
        application/vnd.openxmlformats-officedocument.wordprocessingml.document
        application/vnd.openxmlformats-officedocument.presentationml.presentation
        application/vnd.openxmlformats-officedocument.spreadsheetml.sheet

Image Types:
      image/jpeg, image/png

Video Types: 
        video/mp4, video/3gp
```

Check the official [documentation](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#supported-media-types)


We must specify the correct `content-type` header to download a file. The value matches the media types described above; it uses the ones defined by the Internet Assigned Numbers Authority (IANA). Check the list of complete [content-type headers available](https://www.iana.org/assignments/media-types/media-types.xhtml)

### Solution
I added a class that raises an error if the media_type is invalid. 

If you're using a webhook and want to write the media type received, you should use the media_type of the Webhook's payload and send it through the `MediasApi#download` method. 
