### PR TITLE
Add Suport to image/webp sticker media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased 
 
+- Add Support to image/webp sticker media. @renatovico [#94](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/94)
+
 # v 0.9.1
 - Invalidate unsupported and invalid media types @ignacio-chiazzo [#89](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/89)
 

--- a/lib/whatsapp_sdk/resource/media_types.rb
+++ b/lib/whatsapp_sdk/resource/media_types.rb
@@ -22,9 +22,10 @@ module WhatsappSdk
         application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
       ].freeze
       IMAGE_TYPES = %w[image/jpeg image/png].freeze
+      STICKER_TYPES = %w[image/webp].freeze
       VIDEO_TYPES = %w[video/mp4 video/3gp].freeze
 
-      SUPPORTED_MEDIA_TYPES = [AUDIO_TYPES + DOCUMENT_TYPES + IMAGE_TYPES + VIDEO_TYPES].flatten.freeze
+      SUPPORTED_MEDIA_TYPES = [AUDIO_TYPES + DOCUMENT_TYPES + IMAGE_TYPES + STICKER_TYPES + VIDEO_TYPES].flatten.freeze
     end
   end
 end


### PR DESCRIPTION
Fix [https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/94](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/94)


test continues works:

``` bundle exec rake test
Run options: --seed 29078

# Running: ....

Finished in 0.055045s, 1943.8641 runs/s, 13043.8732 assertions/s.

107 runs, 718 assertions, 0 failures, 0 errors, 0 skips ```