### PR TITLE
build: update faraday version to 2.7.x series

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem("faraday")
+gem("faraday", "~> 2.7.10")
 gem("faraday-multipart")
 gem("rake", ">= 12.3.3")
 gem('sorbet-runtime')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.9.1)
-      faraday (~> 2.3.0)
+    whatsapp_sdk (0.9.2)
+      faraday (~> 2.7.10)
       faraday-multipart (~> 1.0.4)
       sorbet-runtime (~> 0.5.1)
       zeitwerk (~> 2.6.0)
@@ -17,12 +17,12 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    faraday (2.3.0)
-      faraday-net_http (~> 2.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
-    faraday-net_http (2.1.0)
+    faraday-net_http (3.0.2)
     hashdiff (1.0.1)
     method_source (1.0.0)
     minitest (5.16.1)
@@ -113,7 +113,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.3)
-  faraday
+  faraday (~> 2.7.10)
   faraday-multipart
   minitest (~> 5.0)
   mocha

--- a/whatsapp_sdk.gemspec
+++ b/whatsapp_sdk.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency('sorbet-runtime', "~>0.5.1")
 
-  spec.add_dependency("faraday", "~> 2.3.0")
+  spec.add_dependency("faraday", "~> 2.7.10")
   spec.add_dependency("faraday-multipart", "~> 1.0.4")
   spec.add_dependency("zeitwerk", "~> 2.6.0")
   spec.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
Just a Faraday update from `2.3.0` (Release date May 6, 2022) to `2.7.x` series