### PR TITLE
Refactor error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased 
 
+- Rename `error` module with `errors`. @ignacio-chiazzo [#101](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/101)
 - Add Support to image/webp sticker media. @renatovico [#94](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/94)
 
 # v 0.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased 
-- Rename `error` module with `errors`. @ignacio-chiazzo [#101](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/101)
+- [Breaking Change] Rename `error` module with `errors`. @ignacio-chiazzo [#101](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/101)
+
+If you are calling an error using `WhatsappSdk::Resource::Error`, you should update it to `WhatsappSdk::Resource::Errors`, e.g. `WhatsappSdk::Resource::Errors::MissingArgumentError`
+
 
 # v 0.9.2
 - Add Support to image/webp sticker media. @renatovico [#94](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/94)

--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -111,7 +111,7 @@ module WhatsappSdk
       def send_image(
         sender_id:, recipient_number:, image_id: nil, link: nil, caption: "", message_id: nil
       )
-        raise WhatsappSdk::Resource::Error::MissingArgumentError, "image_id or link is required" if !image_id && !link
+        raise WhatsappSdk::Resource::Errors::MissingArgumentError, "image_id or link is required" if !image_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -153,7 +153,7 @@ module WhatsappSdk
         ).returns(WhatsappSdk::Api::Response)
       end
       def send_audio(sender_id:, recipient_number:, audio_id: nil, link: nil, message_id: nil)
-        raise WhatsappSdk::Resource::Error::MissingArgumentError, "audio_id or link is required" if !audio_id && !link
+        raise WhatsappSdk::Resource::Errors::MissingArgumentError, "audio_id or link is required" if !audio_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -195,7 +195,7 @@ module WhatsappSdk
       def send_video(
         sender_id:, recipient_number:, video_id: nil, link: nil, caption: "", message_id: nil
       )
-        raise WhatsappSdk::Resource::Error::MissingArgumentError, "video_id or link is required" if !video_id && !link
+        raise WhatsappSdk::Resource::Errors::MissingArgumentError, "video_id or link is required" if !video_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -241,7 +241,10 @@ module WhatsappSdk
       def send_document(
         sender_id:, recipient_number:, document_id: nil, link: nil, caption: "", message_id: nil
       )
-        raise WhatsappSdk::Resource::Error::MissingArgumentError, "document or link is required" if !document_id && !link
+        if !document_id && !link
+          raise WhatsappSdk::Resource::Errors::MissingArgumentError,
+                "document or link is required"
+        end
 
         params = {
           messaging_product: "whatsapp",
@@ -283,7 +286,7 @@ module WhatsappSdk
         ).returns(WhatsappSdk::Api::Response)
       end
       def send_sticker(sender_id:, recipient_number:, sticker_id: nil, link: nil, message_id: nil)
-        raise WhatsappSdk::Resource::Error::MissingArgumentError, "sticker or link is required" if !sticker_id && !link
+        raise WhatsappSdk::Resource::Errors::MissingArgumentError, "sticker or link is required" if !sticker_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -371,7 +374,10 @@ module WhatsappSdk
       def send_interactive_message(
         sender_id:, recipient_number:, interactive: nil, interactive_json: nil, message_id: nil
       )
-        raise WhatsappSdk::Resource::Error::MissingArgumentError, "interactive or interactive_json is required" if !interactive && !interactive_json
+        if !interactive && !interactive_json
+          raise WhatsappSdk::Resource::Errors::MissingArgumentError,
+                "interactive or interactive_json is required"
+        end
 
         params = {
           messaging_product: "whatsapp",
@@ -446,7 +452,10 @@ module WhatsappSdk
       def send_template(
         sender_id:, recipient_number:, name:, language:, components: nil, components_json: nil
       )
-        raise WhatsappSdk::Resource::Error::MissingArgumentError, "components or components_json is required" if !components && !components_json
+        if !components && !components_json
+          raise WhatsappSdk::Resource::Errors::MissingArgumentError,
+                "components or components_json is required"
+        end
 
         params = {
           messaging_product: "whatsapp",

--- a/lib/whatsapp_sdk/api/messages.rb
+++ b/lib/whatsapp_sdk/api/messages.rb
@@ -11,19 +11,6 @@ module WhatsappSdk
 
       DEFAULT_HEADERS = T.let({ 'Content-Type' => 'application/json' }.freeze, Hash)
 
-      class MissingArgumentError < StandardError
-        extend T::Sig
-
-        sig { returns(String) }
-        attr_reader :message
-
-        sig { params(message: String).void }
-        def initialize(message)
-          @message = message
-          super(message)
-        end
-      end
-
       # Send a text message.
       #
       # @param sender_id [Integer] Sender' phone number.
@@ -124,7 +111,7 @@ module WhatsappSdk
       def send_image(
         sender_id:, recipient_number:, image_id: nil, link: nil, caption: "", message_id: nil
       )
-        raise MissingArgumentError, "image_id or link is required" if !image_id && !link
+        raise WhatsappSdk::Resource::Error::MissingArgumentError, "image_id or link is required" if !image_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -166,7 +153,7 @@ module WhatsappSdk
         ).returns(WhatsappSdk::Api::Response)
       end
       def send_audio(sender_id:, recipient_number:, audio_id: nil, link: nil, message_id: nil)
-        raise MissingArgumentError, "audio_id or link is required" if !audio_id && !link
+        raise WhatsappSdk::Resource::Error::MissingArgumentError, "audio_id or link is required" if !audio_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -208,7 +195,7 @@ module WhatsappSdk
       def send_video(
         sender_id:, recipient_number:, video_id: nil, link: nil, caption: "", message_id: nil
       )
-        raise MissingArgumentError, "video_id or link is required" if !video_id && !link
+        raise WhatsappSdk::Resource::Error::MissingArgumentError, "video_id or link is required" if !video_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -254,7 +241,7 @@ module WhatsappSdk
       def send_document(
         sender_id:, recipient_number:, document_id: nil, link: nil, caption: "", message_id: nil
       )
-        raise MissingArgumentError, "document or link is required" if !document_id && !link
+        raise WhatsappSdk::Resource::Error::MissingArgumentError, "document or link is required" if !document_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -296,7 +283,7 @@ module WhatsappSdk
         ).returns(WhatsappSdk::Api::Response)
       end
       def send_sticker(sender_id:, recipient_number:, sticker_id: nil, link: nil, message_id: nil)
-        raise MissingArgumentError, "sticker or link is required" if !sticker_id && !link
+        raise WhatsappSdk::Resource::Error::MissingArgumentError, "sticker or link is required" if !sticker_id && !link
 
         params = {
           messaging_product: "whatsapp",
@@ -384,7 +371,7 @@ module WhatsappSdk
       def send_interactive_message(
         sender_id:, recipient_number:, interactive: nil, interactive_json: nil, message_id: nil
       )
-        raise MissingArgumentError, "interactive or interactive_json is required" if !interactive && !interactive_json
+        raise WhatsappSdk::Resource::Error::MissingArgumentError, "interactive or interactive_json is required" if !interactive && !interactive_json
 
         params = {
           messaging_product: "whatsapp",
@@ -459,7 +446,7 @@ module WhatsappSdk
       def send_template(
         sender_id:, recipient_number:, name:, language:, components: nil, components_json: nil
       )
-        raise MissingArgumentError, "components or components_json is required" if !components && !components_json
+        raise WhatsappSdk::Resource::Error::MissingArgumentError, "components or components_json is required" if !components && !components_json
 
         params = {
           messaging_product: "whatsapp",

--- a/lib/whatsapp_sdk/api/responses/generic_error_response.rb
+++ b/lib/whatsapp_sdk/api/responses/generic_error_response.rb
@@ -1,0 +1,49 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative "error_response"
+
+module WhatsappSdk
+  module Api
+    module Responses
+      class GenericErrorResponse < ErrorResponse
+        sig { returns(Integer) }
+        attr_reader :code
+
+        sig { returns(T.nilable(Integer)) }
+        attr_reader :subcode
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :message
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :type
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :data
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :fbtrace_id
+
+        sig { params(response: T::Hash[T.untyped, T.untyped]).void }
+        def initialize(response:)
+          @code = T.let(response["code"], Integer)
+          @subcode = T.let(response["error_subcode"], T.nilable(Integer))
+          @message = T.let(response["message"], T.nilable(String))
+          @type = T.let(response["type"], T.nilable(String))
+          @data = T.let(response["data"], T.nilable(String))
+          @fbtrace_id = T.let(response["fbtrace_id"], T.nilable(String))
+          super(response: response)
+        end
+
+        sig { override.params(response: T::Hash[T.untyped, T.untyped]).returns(T.nilable(GenericErrorResponse)) }
+        def self.build_from_response(response:)
+          error_response = response["error"]
+          return unless error_response
+
+          new(response: error_response)
+        end
+      end
+    end
+  end
+end

--- a/lib/whatsapp_sdk/api/responses/message_error_response.rb
+++ b/lib/whatsapp_sdk/api/responses/message_error_response.rb
@@ -1,48 +1,12 @@
 # typed: strict
 # frozen_string_literal: true
 
-require_relative "error_response"
+require_relative "generic_error_response"
 
 module WhatsappSdk
   module Api
     module Responses
-      class MessageErrorResponse < ErrorResponse
-        sig { returns(Integer) }
-        attr_reader :code
-
-        sig { returns(T.nilable(Integer)) }
-        attr_reader :subcode
-
-        sig { returns(T.nilable(String)) }
-        attr_reader :message
-
-        sig { returns(T.nilable(String)) }
-        attr_reader :type
-
-        sig { returns(T.nilable(String)) }
-        attr_reader :data
-
-        sig { returns(T.nilable(String)) }
-        attr_reader :fbtrace_id
-
-        sig { params(response: T::Hash[T.untyped, T.untyped]).void }
-        def initialize(response:)
-          @code = T.let(response["code"], Integer)
-          @subcode = T.let(response["error_subcode"], T.nilable(Integer))
-          @message = T.let(response["message"], T.nilable(String))
-          @type = T.let(response["type"], T.nilable(String))
-          @data = T.let(response["data"], T.nilable(String))
-          @fbtrace_id = T.let(response["fbtrace_id"], T.nilable(String))
-          super(response: response)
-        end
-
-        sig { override.params(response: T::Hash[T.untyped, T.untyped]).returns(T.nilable(MessageErrorResponse)) }
-        def self.build_from_response(response:)
-          error_response = response["error"]
-          return unless error_response
-
-          new(response: error_response)
-        end
+      class MessageErrorResponse < GenericErrorResponse
       end
     end
   end

--- a/lib/whatsapp_sdk/resource/error.rb
+++ b/lib/whatsapp_sdk/resource/error.rb
@@ -4,6 +4,19 @@
 module WhatsappSdk
   module Resource
     module Error
+      class MissingArgumentError < StandardError
+        extend T::Sig
+
+        sig { returns(String) }
+        attr_reader :message
+
+        sig { params(message: String).void }
+        def initialize(message)
+          @message = message
+          super(message)
+        end
+      end
+
       class MissingValue < WhatsappSdk::Error
         extend T::Sig
 

--- a/lib/whatsapp_sdk/resource/errors.rb
+++ b/lib/whatsapp_sdk/resource/errors.rb
@@ -3,7 +3,7 @@
 
 module WhatsappSdk
   module Resource
-    module Error
+    module Errors
       class MissingArgumentError < StandardError
         extend T::Sig
 

--- a/lib/whatsapp_sdk/resource/interactive_action.rb
+++ b/lib/whatsapp_sdk/resource/interactive_action.rb
@@ -103,18 +103,18 @@ module WhatsappSdk
         button_length = button.length
         sections_count = sections.length
         unless button_length.positive?
-          raise WhatsappSdk::Resource::Error::InvalidInteractiveActionButton,
+          raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionButton,
                 "Invalid button in action. Button label is required."
         end
 
         unless button_length <= LIST_BUTTON_TITLE_MAXIMUM
-          raise WhatsappSdk::Resource::Error::InvalidInteractiveActionButton,
+          raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionButton,
                 "Invalid length #{button_length} for button. Maximum length: " \
                 "#{LIST_BUTTON_TITLE_MAXIMUM} characters."
         end
 
         unless (LIST_SECTIONS_MINIMUM..LIST_SECTIONS_MAXIMUM).cover?(sections_count)
-          raise WhatsappSdk::Resource::Error::InvalidInteractiveActionSection,
+          raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionSection,
                 "Invalid length #{sections_count} for sections in action. It should be between " \
                 "#{LIST_SECTIONS_MINIMUM} and #{LIST_SECTIONS_MAXIMUM}."
         end
@@ -125,7 +125,7 @@ module WhatsappSdk
       def validate_reply_button
         buttons_count = buttons.length
         unless (REPLY_BUTTONS_MINIMUM..REPLY_BUTTONS_MAXIMUM).cover?(buttons_count)
-          raise WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton,
+          raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton,
                 "Invalid length #{buttons_count} for buttons in action. It should be between " \
                 "#{REPLY_BUTTONS_MINIMUM} and #{REPLY_BUTTONS_MAXIMUM}."
         end
@@ -133,7 +133,7 @@ module WhatsappSdk
         button_ids = buttons.map(&:id)
         return if button_ids.length.eql?(button_ids.uniq.length)
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton,
               "Duplicate ids #{button_ids} for buttons in action. They should be unique."
       end
     end

--- a/lib/whatsapp_sdk/resource/interactive_action_reply_button.rb
+++ b/lib/whatsapp_sdk/resource/interactive_action_reply_button.rb
@@ -67,7 +67,7 @@ module WhatsappSdk
         title_length = title.length
         return if title_length <= ACTION_BUTTON_TITLE_MAXIMUM
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton,
               "Invalid length #{title_length} for title in button. " \
               "Maximum length: #{ACTION_BUTTON_TITLE_MAXIMUM} characters."
       end
@@ -80,7 +80,7 @@ module WhatsappSdk
         id_length = id.length
         return if id_length <= ACTION_BUTTON_ID_MAXIMUM
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton,
               "Invalid length #{id_length} for id in button. Maximum length: #{ACTION_BUTTON_ID_MAXIMUM} characters."
       end
     end

--- a/lib/whatsapp_sdk/resource/interactive_action_section.rb
+++ b/lib/whatsapp_sdk/resource/interactive_action_section.rb
@@ -53,7 +53,7 @@ module WhatsappSdk
         title_length = title.length
         return if title_length <= ACTION_SECTION_TITLE_MAXIMUM
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionSection,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionSection,
               "Invalid length #{title_length} for title in section. Maximum length: " \
               "#{ACTION_SECTION_TITLE_MAXIMUM} characters."
       end
@@ -63,7 +63,7 @@ module WhatsappSdk
         rows_length = rows.length
         return if rows_length <= ACTION_SECTION_ROWS_MAXIMUM
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionSection,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionSection,
               "Invalid number of rows #{rows_length} in section. Maximum count: " \
               "#{ACTION_SECTION_ROWS_MAXIMUM}."
       end

--- a/lib/whatsapp_sdk/resource/interactive_action_section_row.rb
+++ b/lib/whatsapp_sdk/resource/interactive_action_section_row.rb
@@ -61,7 +61,7 @@ module WhatsappSdk
         title_length = title.length
         return if title_length <= ACTION_SECTION_TITLE_MAXIMUM
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow,
               "Invalid length #{title_length} for title in section row. "\
               "Maximum length: #{ACTION_SECTION_TITLE_MAXIMUM} characters."
       end
@@ -74,7 +74,7 @@ module WhatsappSdk
         id_length = id.length
         return if id_length <= ACTION_SECTION_ID_MAXIMUM
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow,
               "Invalid length #{id_length} for id in section row. Maximum length: "\
               "#{ACTION_SECTION_ID_MAXIMUM} characters."
       end
@@ -84,7 +84,7 @@ module WhatsappSdk
         description_length = description.length
         return if description_length <= ACTION_SECTION_DESCRIPTION_MAXIMUM
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow,
               "Invalid length #{description_length} for description in section " \
               "row. Maximum length: #{ACTION_SECTION_DESCRIPTION_MAXIMUM} characters."
       end

--- a/lib/whatsapp_sdk/resource/interactive_body.rb
+++ b/lib/whatsapp_sdk/resource/interactive_body.rb
@@ -40,7 +40,7 @@ module WhatsappSdk
         text_length = text.length
         return if text_length <= MAXIMUM_LENGTH
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveBody,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveBody,
               "Invalid length #{text_length} for text in body. Maximum length: #{MAXIMUM_LENGTH} characters."
       end
     end

--- a/lib/whatsapp_sdk/resource/interactive_footer.rb
+++ b/lib/whatsapp_sdk/resource/interactive_footer.rb
@@ -40,7 +40,7 @@ module WhatsappSdk
         text_length = text.length
         return if text_length <= MAXIMUM_LENGTH
 
-        raise WhatsappSdk::Resource::Error::InvalidInteractiveFooter,
+        raise WhatsappSdk::Resource::Errors::InvalidInteractiveFooter,
               "Invalid length #{text_length} for text in footer. Maximum length: #{MAXIMUM_LENGTH} characters."
       end
     end

--- a/lib/whatsapp_sdk/resource/interactive_header.rb
+++ b/lib/whatsapp_sdk/resource/interactive_header.rb
@@ -109,7 +109,7 @@ module WhatsappSdk
 
           next unless value.nil?
 
-          raise WhatsappSdk::Resource::Error::MissingValue.new(
+          raise WhatsappSdk::Resource::Errors::MissingValue.new(
             type.serialize,
             "#{type.serialize} is required when the type is #{type_b}"
           )

--- a/lib/whatsapp_sdk/resource/parameter_object.rb
+++ b/lib/whatsapp_sdk/resource/parameter_object.rb
@@ -154,8 +154,8 @@ module WhatsappSdk
           next unless type == type_b
 
           if value.nil?
-            raise WhatsappSdk::Resource::Error::MissingValue.new(type.serialize,
-                                                                 "#{type_b} is required when the type is #{type_b}")
+            raise WhatsappSdk::Resource::Errors::MissingValue.new(type.serialize,
+                                                                  "#{type_b} is required when the type is #{type_b}")
           end
         end
       end

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -134,7 +134,7 @@ module WhatsappSdk
       end
 
       def test_send_image_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Errors::MissingArgumentError) do
           @messages_api.send_image(
             sender_id: 123_123, recipient_number: 56_789,
             image_id: nil, link: nil, caption: ""
@@ -205,7 +205,7 @@ module WhatsappSdk
       end
 
       def test_send_audio_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Errors::MissingArgumentError) do
           @messages_api.send_audio(
             sender_id: 123_123, recipient_number: 56_789, link: nil, audio_id: nil
           )
@@ -255,7 +255,7 @@ module WhatsappSdk
       end
 
       def test_send_video_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Errors::MissingArgumentError) do
           @messages_api.send_video(
             sender_id: 123_123, recipient_number: 56_789, link: nil, video_id: nil
           )
@@ -316,7 +316,7 @@ module WhatsappSdk
       end
 
       def test_send_document_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Errors::MissingArgumentError) do
           @messages_api.send_document(
             sender_id: 123_123, recipient_number: 56_789, link: nil, document_id: nil
           )
@@ -377,7 +377,7 @@ module WhatsappSdk
       end
 
       def test_send_sticker_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Errors::MissingArgumentError) do
           @messages_api.send_sticker(
             sender_id: 123_123, recipient_number: 56_789, link: nil, sticker_id: nil
           )
@@ -497,7 +497,7 @@ module WhatsappSdk
       end
 
       def test_send_template_raises_an_error_when_component_and_component_json_are_not_provided
-        error = assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::MissingArgumentError) do
           @messages_api.send_template(
             sender_id: 123_123, recipient_number: 56_789, name: "template", language: "en_US"
           )

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -134,7 +134,7 @@ module WhatsappSdk
       end
 
       def test_send_image_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Api::Messages::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
           @messages_api.send_image(
             sender_id: 123_123, recipient_number: 56_789,
             image_id: nil, link: nil, caption: ""
@@ -205,7 +205,7 @@ module WhatsappSdk
       end
 
       def test_send_audio_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Api::Messages::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
           @messages_api.send_audio(
             sender_id: 123_123, recipient_number: 56_789, link: nil, audio_id: nil
           )
@@ -255,7 +255,7 @@ module WhatsappSdk
       end
 
       def test_send_video_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Api::Messages::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
           @messages_api.send_video(
             sender_id: 123_123, recipient_number: 56_789, link: nil, video_id: nil
           )
@@ -316,7 +316,7 @@ module WhatsappSdk
       end
 
       def test_send_document_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Api::Messages::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
           @messages_api.send_document(
             sender_id: 123_123, recipient_number: 56_789, link: nil, document_id: nil
           )
@@ -377,7 +377,7 @@ module WhatsappSdk
       end
 
       def test_send_sticker_raises_an_error_if_link_and_image_are_not_provided
-        assert_raises(WhatsappSdk::Api::Messages::MissingArgumentError) do
+        assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
           @messages_api.send_sticker(
             sender_id: 123_123, recipient_number: 56_789, link: nil, sticker_id: nil
           )
@@ -497,7 +497,7 @@ module WhatsappSdk
       end
 
       def test_send_template_raises_an_error_when_component_and_component_json_are_not_provided
-        error = assert_raises(WhatsappSdk::Api::Messages::MissingArgumentError) do
+        error = assert_raises(WhatsappSdk::Resource::Error::MissingArgumentError) do
           @messages_api.send_template(
             sender_id: 123_123, recipient_number: 56_789, name: "template", language: "en_US"
           )

--- a/test/whatsapp/resource/interactive_action_section_row_test.rb
+++ b/test/whatsapp/resource/interactive_action_section_row_test.rb
@@ -7,7 +7,7 @@ module WhatsappSdk
   module Resource
     class InteractionActionSectionRowTest < Minitest::Test
       def test_validation
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow) do
           WhatsappSdk::Resource::InteractiveActionSectionRow.new(
             title: "I am the longer row title",
             id: "section_row",
@@ -19,7 +19,7 @@ module WhatsappSdk
           error.message
         )
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow) do
           WhatsappSdk::Resource::InteractiveActionSectionRow.new(
             title: "I am the row title",
             id: "section_row",
@@ -31,7 +31,7 @@ module WhatsappSdk
           error.message
         )
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow) do
           WhatsappSdk::Resource::InteractiveActionSectionRow.new(
             title: "I am the row title",
             id: "section_row" * 25,

--- a/test/whatsapp/resource/interactive_action_section_test.rb
+++ b/test/whatsapp/resource/interactive_action_section_test.rb
@@ -7,7 +7,7 @@ module WhatsappSdk
   module Resource
     class InteractionActionSectionTest < Minitest::Test
       def test_validation
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSection) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSection) do
           WhatsappSdk::Resource::InteractiveActionSection.new(
             title: "I am the longer section title"
           )

--- a/test/whatsapp/resource/interactive_action_test.rb
+++ b/test/whatsapp/resource/interactive_action_test.rb
@@ -7,7 +7,7 @@ module WhatsappSdk
   module Resource
     class InteractionActionTest < Minitest::Test
       def test_validation
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionButton) do
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ListMessage
           )
@@ -18,7 +18,7 @@ module WhatsappSdk
           error.message
         )
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionButton) do
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ListMessage
           )
@@ -30,7 +30,7 @@ module WhatsappSdk
           error.message
         )
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSection) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSection) do
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ListMessage
           )
@@ -42,7 +42,7 @@ module WhatsappSdk
           error.message
         )
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton) do
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ReplyButton
           )
@@ -53,7 +53,7 @@ module WhatsappSdk
           error.message
         )
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton) do
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ReplyButton
           )

--- a/test/whatsapp/resource/interactive_test.rb
+++ b/test/whatsapp/resource/interactive_test.rb
@@ -15,7 +15,7 @@ module WhatsappSdk
   module Resource
     class InteractiveTest < Minitest::Test
       def test_validation_reply_buttons
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton) do
           interactive_body = WhatsappSdk::Resource::InteractiveBody.new(text: "This is the body!")
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ReplyButton
@@ -49,7 +49,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid length 4 for buttons in action. It should be between 1 and 3.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton) do
           interactive_body = WhatsappSdk::Resource::InteractiveBody.new(text: "This is the body!")
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ReplyButton
@@ -74,7 +74,7 @@ module WhatsappSdk
         assert_equal("Duplicate ids [\"button_1\", \"button_1\"] for buttons in action. They should be unique.",
                      error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton) do
           interactive_body = WhatsappSdk::Resource::InteractiveBody.new(text: "This is the body!")
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ReplyButton
@@ -93,7 +93,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid length 24 for title in button. Maximum length: 20 characters.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionReplyButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionReplyButton) do
           interactive_body = WhatsappSdk::Resource::InteractiveBody.new(text: "This is the body!")
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ReplyButton
@@ -112,7 +112,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid length 287 for id in button. Maximum length: 256 characters.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveFooter) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveFooter) do
           interactive_body = WhatsappSdk::Resource::InteractiveBody.new(text: "This is the body!")
           interactive_footer = WhatsappSdk::Resource::InteractiveFooter.new(text: "Footer " * 10)
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
@@ -143,7 +143,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid length 70 for text in footer. Maximum length: 60 characters.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveBody) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveBody) do
           interactive_body = WhatsappSdk::Resource::InteractiveBody.new(text: "Body " * 250)
           interactive_action = WhatsappSdk::Resource::InteractiveAction.new(
             type: WhatsappSdk::Resource::InteractiveAction::Type::ReplyButton
@@ -174,7 +174,7 @@ module WhatsappSdk
       end
 
       def test_validation_list_messages
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionButton) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionButton) do
           interactive_header = WhatsappSdk::Resource::InteractiveHeader.new(
             type: WhatsappSdk::Resource::InteractiveHeader::Type::Text,
             text: "I am the header!"
@@ -213,7 +213,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid button in action. Button label is required.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSection) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSection) do
           interactive_header = WhatsappSdk::Resource::InteractiveHeader.new(
             type: WhatsappSdk::Resource::InteractiveHeader::Type::Text,
             text: "I am the header!"
@@ -254,7 +254,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid length 25 for title in section. Maximum length: 24 characters.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSection) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSection) do
           interactive_header = WhatsappSdk::Resource::InteractiveHeader.new(
             type: WhatsappSdk::Resource::InteractiveHeader::Type::Text,
             text: "I am the header!"
@@ -297,7 +297,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid number of rows 11 in section. Maximum count: 10.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow) do
           interactive_header = WhatsappSdk::Resource::InteractiveHeader.new(
             type: WhatsappSdk::Resource::InteractiveHeader::Type::Text,
             text: "I am the header!"
@@ -338,7 +338,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid length 27 for title in section row. Maximum length: 24 characters.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow) do
           interactive_header = WhatsappSdk::Resource::InteractiveHeader.new(
             type: WhatsappSdk::Resource::InteractiveHeader::Type::Text,
             text: "I am the header!"
@@ -379,7 +379,7 @@ module WhatsappSdk
         end
         assert_equal("Invalid length 319 for id in section row. Maximum length: 256 characters.", error.message)
 
-        error = assert_raises(WhatsappSdk::Resource::Error::InvalidInteractiveActionSectionRow) do
+        error = assert_raises(WhatsappSdk::Resource::Errors::InvalidInteractiveActionSectionRow) do
           interactive_header = WhatsappSdk::Resource::InteractiveHeader.new(
             type: WhatsappSdk::Resource::InteractiveHeader::Type::Text,
             text: "I am the header!"

--- a/test/whatsapp/resource/parameter_object_test.rb
+++ b/test/whatsapp/resource/parameter_object_test.rb
@@ -7,7 +7,7 @@ require_relative '../../../lib/whatsapp_sdk/resource/media'
 require_relative '../../../lib/whatsapp_sdk/resource/date_time'
 require_relative '../../../lib/whatsapp_sdk/resource/currency'
 require_relative '../../../lib/whatsapp_sdk/error'
-require_relative '../../../lib/whatsapp_sdk/resource/error'
+require_relative '../../../lib/whatsapp_sdk/resource/errors'
 
 module WhatsappSdk
   module Resource
@@ -38,7 +38,7 @@ module WhatsappSdk
               attr_name = :image
             end
 
-            error = assert_raises(WhatsappSdk::Resource::Error::MissingValue) do
+            error = assert_raises(WhatsappSdk::Resource::Errors::MissingValue) do
               T.unsafe(WhatsappSdk::Resource::ParameterObject).new(type: type, attr_name => object)
             end
 


### PR DESCRIPTION
- Rename `error` module with `errors`.
- Move errors to a common folder.