### PR TITLE
Added ability to specify fileds on business_profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Added ability to specify fields param in the busines profile API. @ignacio-chiazzo  https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/119
+
 
 # v 0.11.0
 - Bumped API version to v19. @paulomcnally  https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/116

--- a/lib/whatsapp_sdk/api/business_profile.rb
+++ b/lib/whatsapp_sdk/api/business_profile.rb
@@ -13,11 +13,17 @@ module WhatsappSdk
       #
       # @param phone_number_id [Integer] Phone Number Id.
       # @return [Api::Response] Response object.
-      sig { params(phone_number_id: Integer).returns(Api::Response) }
-      def details(phone_number_id)
+      sig { params(phone_number_id: Integer, fields: T.nilable(T::Array[String])).returns(Api::Response) }
+      def details(phone_number_id, fields: nil)
+        fields = if fields
+                   fields.join(',')
+                 else
+                   DEFAULT_FIELDS
+                 end
+
         response = send_request(
           http_method: "get",
-          endpoint: "#{phone_number_id}/whatsapp_business_profile?fields=#{DEFAULT_FIELDS}"
+          endpoint: "#{phone_number_id}/whatsapp_business_profile?fields=#{fields}"
         )
 
         Api::Response.new(

--- a/test/whatsapp/api/business_profile_test.rb
+++ b/test/whatsapp/api/business_profile_test.rb
@@ -20,6 +20,32 @@ module WhatsappSdk
         assert_mock_error_response(mocked_error_response, response, Responses::MessageErrorResponse)
       end
 
+      def test_details_accepts_fields
+        fields = %w[about address]
+        phone_number_id = 123_456
+        @business_profile_api.stubs(:send_request)
+                             .with(
+                               http_method: "get",
+                               endpoint: "#{phone_number_id}/whatsapp_business_profile?fields=about,address"
+                             ).returns(valid_details_response)
+
+        response = @business_profile_api.details(phone_number_id, fields: fields)
+        assert_business_details_mock_response(valid_detail_response, response)
+      end
+
+      def test_details_sends_all_fields_by_default
+        fields = "about,address,description,email,profile_picture_url,websites,vertical"
+        phone_number_id = 123_456
+        @business_profile_api.stubs(:send_request)
+                             .with(
+                               http_method: "get",
+                               endpoint: "#{phone_number_id}/whatsapp_business_profile?fields=#{fields}"
+                             ).returns(valid_details_response)
+
+        response = @business_profile_api.details(phone_number_id)
+        assert_business_details_mock_response(valid_detail_response, response)
+      end
+
       def test_details_with_success_response
         mock_business_profile_response(valid_details_response)
         response = @business_profile_api.details(123_123)


### PR DESCRIPTION
`business_profile` allows specifying `params` field. https://developers.facebook.com/docs/whatsapp/cloud-api/reference/business-profiles/