### PR TITLE
Validate vertical on business profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
+- Validate Vertical on BusinessProfile update API. @ignacio-chiazzo  https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/120
 - Added ability to specify fields param in the busines profile API. @ignacio-chiazzo  https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/119
-
 
 # v 0.11.0
 - Bumped API version to v19. @paulomcnally  https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/116

--- a/lib/whatsapp_sdk/resource/business_profile.rb
+++ b/lib/whatsapp_sdk/resource/business_profile.rb
@@ -1,0 +1,15 @@
+# typed: strict
+# frozen_string_literal: true
+
+module WhatsappSdk
+  module Resource
+    class BusinessProfile
+      extend T::Sig
+
+      VERTICAL_VALUES = %w[
+        UNDEFINED OTHER AUTO BEAUTY APPAREL EDU ENTERTAIN EVENT_PLAN FINANCE GROCERY
+        GOVT HOTEL HEALTH NONPROFIT PROF_SERVICES RETAIL TRAVEL RESTAURANT NOT_A_BIZ
+      ].freeze
+    end
+  end
+end

--- a/test/whatsapp/api/business_profile_test.rb
+++ b/test/whatsapp/api/business_profile_test.rb
@@ -53,10 +53,26 @@ module WhatsappSdk
         assert_predicate(response, :ok?)
       end
 
+      def test_update_returns_an_error_if_vertical_is_invalid
+        params = { vertical: "invalid_vertical" }
+        mock_business_profile_response(valid_details_response)
+        assert_raises(BusinessProfile::InvalidVertical) do
+          @business_profile_api.update(phone_number_id: 123_123, params: params)
+        end
+      end
+
       def test_update_handles_error_response
         mocked_error_response = mock_error_response(api: @business_profile_api)
         response = @business_profile_api.update(phone_number_id: 123_123, params: valid_detail_response)
         assert_mock_error_response(mocked_error_response, response, Responses::MessageErrorResponse)
+      end
+
+      def test_update_does_not_return_an_error_if_vertical_is_valid
+        params = { vertical: "BEAUTY" }
+        mock_business_profile_response(valid_update_response)
+        response = @business_profile_api.update(phone_number_id: 123_123, params: params)
+        assert_update_details_mock_response(valid_update_response, response)
+        assert_predicate(response, :ok?)
       end
 
       def test_update_with_success_response


### PR DESCRIPTION
Validate `vertical` param without hitting the Cloud API by checking the value. THis could save some $.