### PR TITLE
Fix warning assert_equal with a nil value in it since it's going to f…

### DIFF
--- a/test/whatsapp/api/phone_numbers_test.rb
+++ b/test/whatsapp/api/phone_numbers_test.rb
@@ -180,6 +180,7 @@ module WhatsappSdk
               "message" => "(#100) Param pin must be 6 characters long.",
               "type" => "OAuthException",
               "code" => 100,
+              "error_subcode" => 22,
               "fbtrace_id" => "AVU2ojfLmjKZSKbkWqjA_Uc"
             }
         }
@@ -221,21 +222,29 @@ module WhatsappSdk
       end
 
       def assert_phone_number(expected_phone_number, phone_number)
-        assert_equal(expected_phone_number["id"], phone_number.id)
-        assert_equal(expected_phone_number["display_phone_number"], phone_number.display_phone_number)
-        assert_equal(expected_phone_number["quality_rating"], phone_number.quality_rating)
-        assert_equal(expected_phone_number["verified_name"], phone_number.verified_name)
-        assert_equal(expected_phone_number["code_verification_status"], phone_number.code_verification_status)
-        assert_equal(expected_phone_number["is_official_business_account"], phone_number.is_official_business_account)
-        assert_equal(expected_phone_number["account_mode"], phone_number.account_mode)
-        assert_equal(expected_phone_number["eligibility_for_api_business_global_search"],
-                     phone_number.eligibility_for_api_business_global_search)
-        assert_equal(expected_phone_number["is_pin_enabled"], phone_number.is_pin_enabled)
-        assert_equal(expected_phone_number["name_status"], phone_number.name_status)
-        assert_equal(expected_phone_number["new_name_status"], phone_number.new_name_status)
-        assert_equal(expected_phone_number["status"], phone_number.status)
-        assert_equal(expected_phone_number["search_visibility"], phone_number.search_visibility)
-        assert_equal(expected_phone_number["certificate"], phone_number.certificate)
+        [
+          [expected_phone_number["id"], phone_number.id],
+          [expected_phone_number["display_phone_number"], phone_number.display_phone_number],
+          [expected_phone_number["quality_rating"], phone_number.quality_rating],
+          [expected_phone_number["verified_name"], phone_number.verified_name],
+          [expected_phone_number["code_verification_status"], phone_number.code_verification_status],
+          [expected_phone_number["is_official_business_account"], phone_number.is_official_business_account],
+          [expected_phone_number["account_mode"], phone_number.account_mode],
+          [expected_phone_number["eligibility_for_api_business_global_search"],
+           phone_number.eligibility_for_api_business_global_search],
+          [expected_phone_number["is_pin_enabled"], phone_number.is_pin_enabled],
+          [expected_phone_number["name_status"], phone_number.name_status],
+          [expected_phone_number["new_name_status"], phone_number.new_name_status],
+          [expected_phone_number["status"], phone_number.status],
+          [expected_phone_number["search_visibility"], phone_number.search_visibility],
+          [expected_phone_number["certificate"], phone_number.certificate]
+        ].each do |expected, actual|
+          if expected.nil?
+            assert_nil(actual)
+          else
+            assert_equal(expected, actual)
+          end
+        end
       end
     end
   end

--- a/test/whatsapp/api/templates_test.rb
+++ b/test/whatsapp/api/templates_test.rb
@@ -277,13 +277,21 @@ module WhatsappSdk
       end
 
       def assert_templates_mock_response(expected_template_response, template_response)
-        assert_equal(Responses::TemplateDataResponse, template_response.class)
-        assert_equal(expected_template_response["id"], template_response.template.id)
-        assert_equal(expected_template_response["status"], template_response.template.status.serialize)
-        assert_equal(expected_template_response["category"], template_response.template.category.serialize)
-        assert_equal(expected_template_response["language"], template_response.template.language)
-        assert_equal(expected_template_response["name"], template_response.template.name)
-        assert_equal(expected_template_response["components"], template_response.template.components_json)
+        [
+          [Responses::TemplateDataResponse, template_response.class],
+          [expected_template_response["id"], template_response.template.id],
+          [expected_template_response["status"], template_response.template.status.serialize],
+          [expected_template_response["category"], template_response.template.category.serialize],
+          [expected_template_response["language"], template_response.template.language],
+          [expected_template_response["name"], template_response.template.name],
+          [expected_template_response["components"], template_response.template.components_json]
+        ].each do |expected, actual|
+          if expected.nil?
+            assert_nil(actual)
+          else
+            assert_equal(expected, actual)
+          end
+        end
       end
 
       def assert_ok_response(response)


### PR DESCRIPTION
…ail in Minitest 6

Remove warnings 
<img width="1432" alt="Screenshot 2024-02-10 at 11 51 22 AM" src="https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/assets/11672878/033b5157-f707-4f28-b63c-73da5f6d9ce0">


<img width="1112" alt="Screenshot 2024-02-10 at 11 54 25 AM" src="https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/assets/11672878/12201779-42ff-4be4-b7af-4c76ff67a8fa">

