### PR TITLE
Configure logger in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,26 @@ Available API version can be found [here](https://developers.facebook.com/docs/g
 WhatsappSdk.configure do |config|
   config.access_token = ACCESS_TOKEN
   config.api_version = API_VERSION
+  config.logger = Logger.new(STDOUT) # optional, Faraday logger to attach
+  config.logger_options = { bodies: true } # optional, they are all valid logger_options for Faraday
 end
 ```
+More Details on Faraday Logger Options are [here](https://lostisland.github.io/faraday/#/middleware/included/logging?id=logging).
 
 OR 2) Create a `Client` instance and pass it to the `Messages`, `Medias` or `PhoneNumbers` instance like this:
 
+**Without Logger:**
 ```ruby
 client = WhatsappSdk::Api::Client.new("<ACCESS TOKEN>") # replace this with a valid access token
 messages_api = WhatsappSdk::Api::Messages.new(client)
 ```
-
+**With Logger:**
+```ruby
+logger = Logger.new(STDOUT)
+logger_options = { bodies: true }
+client = WhatsappSdk::Api::Client.new("<ACCESS TOKEN>", "<API VERSION>", logger, logger_options) # replace this with a valid access token
+messages_api = WhatsappSdk::Api::Messages.new(client)
+```
 Each API operation returns a `WhatsappSdk::Api::Response` that contains `data` and `error` and a couple of helpful functions such as `ok?` and `error?`. There are three types of responses `WhatsappSdk::Api::MessageDataResponse`, `WhatsappSdk::Api::PhoneNumberDataResponse` and `WhatsappSdk::Api::PhoneNumbersDataResponse`. Each of them contains different attributes.
 
 ## Set up a Meta app

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -12,9 +12,23 @@ module WhatsappSdk
 
       API_VERSIONS = T.let(YAML.load_file("config/api_versions.yml"), T::Array[String])
 
-      sig { params(access_token: String, api_version: String).void }
-      def initialize(access_token, api_version = ApiConfiguration::DEFAULT_API_VERSION)
+      sig do
+        params(
+          access_token: String,
+          api_version: String,
+          logger: T.nilable(T.any(Logger, T.class_of(Logger))),
+          logger_options: Hash
+        ).void
+      end
+      def initialize(
+        access_token,
+        api_version = ApiConfiguration::DEFAULT_API_VERSION,
+        logger = nil,
+        logger_options = {}
+      )
         @access_token = access_token
+        @logger = logger
+        @logger_options = logger_options
 
         validate_api_version(api_version)
         @api_version = api_version
@@ -83,6 +97,7 @@ module WhatsappSdk
           client.request(:url_encoded)
           client.adapter(::Faraday.default_adapter)
           client.headers['Authorization'] = "Bearer #{@access_token}" unless @access_token.nil?
+          client.response(:logger, @logger, @logger_options) unless @logger.nil?
         end
       end
 

--- a/lib/whatsapp_sdk/configuration.rb
+++ b/lib/whatsapp_sdk/configuration.rb
@@ -49,7 +49,7 @@ module WhatsappSdk
 
     sig { returns(Api::Client) }
     def client
-      Api::Client.new(access_token, logger, logger_options, api_version)
+      Api::Client.new(access_token, api_version, logger, logger_options)
     end
   end
 end

--- a/lib/whatsapp_sdk/configuration.rb
+++ b/lib/whatsapp_sdk/configuration.rb
@@ -12,21 +12,44 @@ module WhatsappSdk
   class Configuration
     extend T::Sig
 
+    logger_or_subclass_or_nil = T.nilable(T.any(Logger, T.class_of(Logger)))
+
     sig { returns(String) }
     attr_accessor :access_token
 
     sig { returns(String) }
     attr_accessor :api_version
 
-    sig { params(access_token: String, api_version: String).void }
-    def initialize(access_token = "", api_version = Api::ApiConfiguration::DEFAULT_API_VERSION)
+    # loggers like ActiveSupport::Logger (Rails.logger) is a subclass of Logger
+    sig { returns(logger_or_subclass_or_nil) }
+    attr_accessor :logger
+
+    sig { returns(Hash) }
+    attr_accessor :logger_options
+
+    sig do
+      params(
+        access_token: String,
+        api_version: String,
+        logger: logger_or_subclass_or_nil,
+        logger_options: Hash
+      ).void
+    end
+    def initialize(
+      access_token = "",
+      api_version = Api::ApiConfiguration::DEFAULT_API_VERSION,
+      logger = nil,
+      logger_options = {}
+    )
       @access_token = access_token
       @api_version = api_version
+      @logger = logger
+      @logger_options = logger_options
     end
 
     sig { returns(Api::Client) }
     def client
-      Api::Client.new(access_token, api_version)
+      Api::Client.new(access_token, logger, logger_options, api_version)
     end
   end
 end

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -77,7 +77,6 @@ module WhatsappSdk
         assert_match('INFO -- response: ', logged_string)
       end
 
-
       def test_logs_http_requests_into_the_logger_with_response_body
         logger_io = StringIO.new
         client = Client.new(

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -62,6 +62,45 @@ module WhatsappSdk
         end
       end
 
+      def test_logs_http_requests_into_the_logger_without_response_body
+        logger_io = StringIO.new
+        client = Client.new('test_token', ApiConfiguration::DEFAULT_API_VERSION, Logger.new(logger_io))
+
+        stub_test_request(:get)
+        client.send_request(endpoint: 'test', http_method: 'get')
+
+        logged_string = logger_io.string
+        middleware_handlers = faraday_middlewares(client)
+
+        assert_includes(middleware_handlers, Faraday::Response::Logger)
+        assert_match_logger_output!(logged_string)
+        assert_match('INFO -- response: ', logged_string)
+      end
+
+
+      def test_logs_http_requests_into_the_logger_with_response_body
+        logger_io = StringIO.new
+        client = Client.new(
+          'test_token',
+          ApiConfiguration::DEFAULT_API_VERSION,
+          Logger.new(logger_io),
+          { bodies: true }
+        )
+
+        stub_test_request(:get)
+        client.send_request(endpoint: 'test', http_method: 'get')
+
+        logged_string = logger_io.string
+        assert_match_logger_output!(logged_string)
+        assert_match('INFO -- response: {"success":true}', logged_string)
+      end
+
+      def test_should_not_log_when_logger_not_configured
+        # Validates whether the logger was configured into faraday or not
+        middleware_handlers = faraday_middlewares(@client)
+        refute_includes(middleware_handlers, Faraday::Response::Logger)
+      end
+
       private
 
       def stub_test_request(method_name, body: {}, headers: {}, response_status: 200, response_body: { success: true },
@@ -71,6 +110,18 @@ module WhatsappSdk
                                        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
                                        'Authorization' => 'Bearer test_token' }.merge(headers))
           .to_return(status: response_status, body: response_body.to_json, headers: {})
+      end
+
+      def faraday_middlewares(client)
+        faraday = client.send(:faraday, url: '')
+        faraday.builder.handlers
+      end
+
+      def assert_match_logger_output!(logged_string)
+        assert_match('INFO -- request: GET https://graph.facebook.com/v19.0/test', logged_string)
+        assert_match('INFO -- request: Authorization: "Bearer test_token"', logged_string)
+        assert_match('User-Agent: "Faraday v2.7.12"', logged_string)
+        assert_match('INFO -- response: Status 200', logged_string)
       end
     end
   end


### PR DESCRIPTION
**Closes:** #121

The PR proposes the following changes:
- Configure logger for the Faraday
- If a logger is not given, then no logger would be configured