### PR TITLE
Add 0.12.0 version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+
+# v 0.12.0
+- Added ability to specify logger @chahmedejaz [#129](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/129)
+- Allow download of unsupported media types @dvuckovic [#128](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/128)
+- Allow users to specify the API version. @conr [#126](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/126)
 - Use http multipart only when is needed. @ignacio-chiazzo [#123](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/123)
 - Validate Vertical on BusinessProfile update API. @ignacio-chiazzo [#120](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/120)
 - Added ability to specify fields param in the busines profile API. @ignacio-chiazzo [#119](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/119)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.11.0)
+    whatsapp_sdk (0.12.0)
       faraday (~> 2)
       faraday-multipart (~> 1)
       sorbet-runtime (~> 0.5)
@@ -17,7 +17,7 @@ GEM
     coderay (1.1.3)
     crack (0.4.5)
       rexml
-    faraday (2.7.12)
+    faraday (2.8.1)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -28,7 +28,7 @@ GEM
     method_source (1.0.0)
     minitest (5.16.1)
     mocha (1.14.0)
-    multipart-post (2.3.0)
+    multipart-post (2.4.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -79,8 +79,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.35)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   arm64-darwin-21

--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module WhatsappSdk
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -119,7 +119,7 @@ module WhatsappSdk
       def assert_match_logger_output!(logged_string)
         assert_match('INFO -- request: GET https://graph.facebook.com/v19.0/test', logged_string)
         assert_match('INFO -- request: Authorization: "Bearer test_token"', logged_string)
-        assert_match('User-Agent: "Faraday v2.7.12"', logged_string)
+        assert_match('User-Agent: "Faraday', logged_string)
         assert_match('INFO -- response: Status 200', logged_string)
       end
     end

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -39,6 +39,7 @@ module WhatsappSdk
         response = @messages_api.send_text(
           sender_id: 123_123, recipient_number: 56_789, message: "hola"
         )
+
         assert_mock_error_response(mocked_error_response, response, Responses::MessageErrorResponse)
       end
 
@@ -47,6 +48,7 @@ module WhatsappSdk
         message_response = @messages_api.send_text(
           sender_id: 123_123, recipient_number: 56_789, message: "hola"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -67,6 +69,7 @@ module WhatsappSdk
         message_response = @messages_api.send_text(
           sender_id: 123_123, recipient_number: 56_789, message: "hola"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -88,6 +91,7 @@ module WhatsappSdk
         message_response = @messages_api.send_text(
           sender_id: 123_123, recipient_number: 56_789, message: "hola", message_id: "wamid.987654321"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -130,6 +134,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           longitude: longitude, latitude: latitude, name: name, address: address
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -149,6 +154,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           image_id: "123", link: nil, caption: ""
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -170,6 +176,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           link: image_link, caption: "Ignacio Chiazzo Profile"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -192,6 +199,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           image_id: image_id, caption: "Ignacio Chiazzo Profile"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -201,6 +209,7 @@ module WhatsappSdk
         message_response = @messages_api.send_audio(
           sender_id: 123_123, recipient_number: 56_789, link: "1234"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -231,6 +240,7 @@ module WhatsappSdk
         message_response = @messages_api.send_audio(
           sender_id: 123_123, recipient_number: 56_789, link: audio_link
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -253,6 +263,7 @@ module WhatsappSdk
         message_response = @messages_api.send_audio(
           sender_id: 123_123, recipient_number: 56_789, audio_id: audio_id
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -271,6 +282,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           video_id: "123", link: nil, caption: ""
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -292,6 +304,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           link: video_link, caption: "Ignacio Chiazzo Profile"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -314,6 +327,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           video_id: video_id, caption: "Ignacio Chiazzo Profile"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -332,6 +346,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           document_id: "123", link: nil, caption: ""
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -353,6 +368,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           link: document_link, caption: "Ignacio Chiazzo Profile"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -375,6 +391,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           document_id: document_id, caption: "Ignacio Chiazzo Profile"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -393,6 +410,7 @@ module WhatsappSdk
           sender_id: 123_123, recipient_number: 56_789,
           sticker_id: "123", link: nil
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -413,6 +431,7 @@ module WhatsappSdk
         message_response = @messages_api.send_sticker(
           sender_id: 123_123, recipient_number: 56_789, link: sticker_link
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -434,6 +453,7 @@ module WhatsappSdk
         message_response = @messages_api.send_sticker(
           sender_id: 123_123, recipient_number: 56_789, sticker_id: sticker_id
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -443,6 +463,7 @@ module WhatsappSdk
         message_response = @messages_api.send_contacts(
           sender_id: 123_123, recipient_number: 56_789, contacts: [create_contact]
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -464,6 +485,7 @@ module WhatsappSdk
         message_response = @messages_api.send_contacts(
           sender_id: 123_123, recipient_number: 56_789, contacts: contacts
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -483,10 +505,10 @@ module WhatsappSdk
           sender_id: 123_123, message_id: "12345"
         )
 
-        assert_equal(Response, message_response.class)
+        assert_instance_of(Response, message_response)
         assert_nil(message_response.error)
         assert_predicate(message_response, :ok?)
-        assert_equal(Responses::ReadMessageDataResponse, message_response.data.class)
+        assert_instance_of(Responses::ReadMessageDataResponse, message_response.data)
         assert_predicate(message_response.data, :success?)
       end
 
@@ -495,6 +517,7 @@ module WhatsappSdk
         response = @messages_api.read_message(
           sender_id: 123_123, message_id: "12345"
         )
+
         assert_mock_error_response(mocked_error_response, response, Responses::MessageErrorResponse)
         assert_predicate(response, :error?)
       end
@@ -525,6 +548,7 @@ module WhatsappSdk
             ]
           }]
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -577,78 +601,78 @@ module WhatsappSdk
           ]
         )
 
-        @messages_api.expects(:send_request).with({
-                                                    endpoint: "123123/messages",
-                                                    params: {
-                                                      messaging_product: "whatsapp",
-                                                      to: 12_345_678,
-                                                      recipient_type: "individual",
-                                                      type: "template",
-                                                      template: {
-                                                        name: "hello_world",
-                                                        language: { code: "en_US" },
-                                                        components: [
-                                                          {
-                                                            type: "header",
-                                                            parameters: [
-                                                              {
-                                                                type: "image",
-                                                                image: {
-                                                                  link: "http(s)://URL"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            type: "body",
-                                                            parameters: [
-                                                              {
-                                                                type: "text",
-                                                                text: "TEXT_STRING"
-                                                              },
-                                                              {
-                                                                type: "currency",
-                                                                currency: {
-                                                                  fallback_value: "1000",
-                                                                  code: "USD",
-                                                                  amount_1000: 1000
-                                                                }
-                                                              },
-                                                              {
-                                                                type: "date_time",
-                                                                date_time: {
-                                                                  fallback_value: "2020-01-01T00:00:00Z"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            type: "button",
-                                                            sub_type: "quick_reply",
-                                                            index: 0,
-                                                            parameters: [
-                                                              {
-                                                                type: "payload",
-                                                                payload: "PAYLOAD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            type: "button",
-                                                            sub_type: "quick_reply",
-                                                            index: 1,
-                                                            parameters: [
-                                                              {
-                                                                type: "payload",
-                                                                payload: "PAYLOAD"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    },
-                                                    headers: { "Content-Type" => "application/json" }
-                                                  }).returns(valid_response(valid_contacts, valid_messages))
+        @messages_api.expects(:send_request).with(
+          endpoint: "123123/messages",
+          params: {
+            messaging_product: "whatsapp",
+            to: 12_345_678,
+            recipient_type: "individual",
+            type: "template",
+            template: {
+              name: "hello_world",
+              language: { code: "en_US" },
+              components: [
+                {
+                  type: "header",
+                  parameters: [
+                    {
+                      type: "image",
+                      image: {
+                        link: "http(s)://URL"
+                      }
+                    }
+                  ]
+                },
+                {
+                  type: "body",
+                  parameters: [
+                    {
+                      type: "text",
+                      text: "TEXT_STRING"
+                    },
+                    {
+                      type: "currency",
+                      currency: {
+                        fallback_value: "1000",
+                        code: "USD",
+                        amount_1000: 1000
+                      }
+                    },
+                    {
+                      type: "date_time",
+                      date_time: {
+                        fallback_value: "2020-01-01T00:00:00Z"
+                      }
+                    }
+                  ]
+                },
+                {
+                  type: "button",
+                  sub_type: "quick_reply",
+                  index: 0,
+                  parameters: [
+                    {
+                      type: "payload",
+                      payload: "PAYLOAD"
+                    }
+                  ]
+                },
+                {
+                  type: "button",
+                  sub_type: "quick_reply",
+                  index: 1,
+                  parameters: [
+                    {
+                      type: "payload",
+                      payload: "PAYLOAD"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          headers: { "Content-Type" => "application/json" }
+        ).returns(valid_response(valid_contacts, valid_messages))
 
         message_response = @messages_api.send_template(
           sender_id: 123_123, recipient_number: 12_345_678, name: "hello_world", language: "en_US",
@@ -664,6 +688,7 @@ module WhatsappSdk
         message_response = @messages_api.send_reaction(
           sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "\\uD83D\\uDE00"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -687,6 +712,7 @@ module WhatsappSdk
         message_response = @messages_api.send_reaction(
           sender_id: 123_123, recipient_number: 56_789, message_id: "12345", emoji: "\\uD83D\\uDE00"
         )
+
         assert_mock_response(valid_contacts, valid_messages, message_response)
         assert_predicate(message_response, :ok?)
       end
@@ -981,7 +1007,7 @@ module WhatsappSdk
       end
 
       def assert_mock_response(_expected_contacts, _expected_messages, message_response)
-        assert_equal(Response, message_response.class)
+        assert_instance_of(Response, message_response)
         assert_nil(message_response.error)
         assert_predicate(message_response, :ok?)
         assert_equal(1, message_response.data.contacts.size)

--- a/test/whatsapp/version_test.rb
+++ b/test/whatsapp/version_test.rb
@@ -6,6 +6,6 @@ require 'version'
 
 class VersionTest < Minitest::Test
   def test_that_it_has_a_version_number
-    assert_equal("0.11.0", WhatsappSdk::VERSION)
+    assert_equal("0.12.0", WhatsappSdk::VERSION)
   end
 end


### PR DESCRIPTION
This version includes:


- Added ability to specify logger @chahmedejaz [#129](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/129)
- Allow download of unsupported media types @dvuckovic [#128](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/128)
- Allow users to specify the API version. @conr [#126](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/126)
- Use http multipart only when is needed. @ignacio-chiazzo [#123](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/123)
- Validate Vertical on BusinessProfile update API. @ignacio-chiazzo [#120](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/120)
- Added the ability to specify fields param in the business profile API. @ignacio-chiazzo [#119](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/119)

Thanks @chahmedejaz, @conr and @dvuckovic for your contributions

