### PR TITLE
Fix error autoload path

### DIFF
--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -10,7 +10,10 @@ module WhatsappSdk
     class Client
       extend T::Sig
 
-      API_VERSIONS = T.let(YAML.load_file("config/api_versions.yml"), T::Array[String])
+      API_VERSIONS = T.let(
+        YAML.load_file(File.join(__dir__, "../../../config/api_versions.yml")),
+        T::Array[String]
+      )
 
       sig do
         params(


### PR DESCRIPTION
Users reported an error with autoloading: `rails zeitwerk:check crashes #132.`

The problem is that when including the gem in a Rails app, the directory used to load the YAML file is relative to the Rails app, not the gem directory. To solve the issue, I used `__dir__`. 

https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/assets/11672878/42148650-6179-42fd-8e8c-9988b93a43a8

https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/132


# Steps to reproduce it

I used the [Ruby On Rails WhatsappSDK Example](https://github.com/ignacio-chiazzo/ruby_on_rails_whatsapp_example/pull/3) repository. With `v 0.12.0`, the command crashes; with local changes, it passes.