### PR TITLE
Add location header to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,9 @@ WhatsApp message templates are specific message formats that businesses use to s
 currency = WhatsappSdk::Resource::Currency.new(code: "USD", amount: 1000, fallback_value: "1000")
 date_time = WhatsappSdk::Resource::DateTime.new(fallback_value: "2020-01-01T00:00:00Z")
 image = WhatsappSdk::Resource::Media.new(type: "image", link: "http(s)://URL")
+location = WhatsappSdk::Resource::Location.new(
+  latitude: 25.779510, longitude: -80.338631, name: "miami store", address: "820 nw 87th ave, miami, fl"
+)
 
 parameter_image = WhatsappSdk::Resource::ParameterObject.new(type: WhatsappSdk::Resource::ParameterObject::Type::Image, image: image)
 # You can also use a plain string as type e.g.
@@ -378,6 +381,10 @@ parameter_image = WhatsappSdk::Resource::ParameterObject.new(type: WhatsappSdk::
 parameter_text = WhatsappSdk::Resource::ParameterObject.new(type: WhatsappSdk::Resource::ParameterObject::Type::Text, text: "TEXT_STRING")
 parameter_currency = WhatsappSdk::Resource::ParameterObject.new(type: WhatsappSdk::Resource::ParameterObject::Type::Currency, currency: currency)
 parameter_date_time = WhatsappSdk::Resource::ParameterObject.new(type: WhatsappSdk::Resource::ParameterObject::Type::DateTime, date_time: date_time)
+parameter_location = WhatsappSdk::Resource::ParameterObject.new(
+  type: WhatsappSdk::Resource::ParameterObject::Type::Location,
+  location: location
+)
 
 header_component = WhatsappSdk::Resource::Component.new(
   type: WhatsappSdk::Resource::Component::Type::Header,
@@ -405,6 +412,11 @@ button_component2 = WhatsappSdk::Resource::Component.new(
   parameters: [
     WhatsappSdk::Resource::ButtonParameter.new(type: WhatsappSdk::Resource::ButtonParameter::Type::Payload, payload: "PAYLOAD")
   ]
+)
+
+location_component = WhatsappSdk::Resource::Component.new(
+  type: WhatsappSdk::Resource::Component::Type::Header,
+  parameters: [parameter_location]
 )
 @messages_api.send_template(sender_id: 12_345, recipient_number: 12345678, name: "hello_world", language: "en_US", components_json: [component_1])
 ```

--- a/example.rb
+++ b/example.rb
@@ -271,14 +271,16 @@ response_with_object = messages_api.send_template(sender_id: SENDER_ID, recipien
                                                   name: "hello_world", language: "en_US", components: [])
 puts response_with_object
 
-# Send a template with components.Remember to create the template first.
+# Send a template with components (Remember to create the template first).
 header_component = WhatsappSdk::Resource::Component.new(
   type: WhatsappSdk::Resource::Component::Type::Header
 )
-
 image = WhatsappSdk::Resource::Media.new(type: "image", link: "http(s)://URL", caption: "caption")
 document = WhatsappSdk::Resource::Media.new(type: "document", link: "http(s)://URL", filename: "txt.rb")
 video = WhatsappSdk::Resource::Media.new(type: "video", id: "123")
+location = WhatsappSdk::Resource::Location.new(
+  latitude: 25.779510, longitude: -80.338631, name: "miami store", address: "820 nw 87th ave, miami, fl"
+)
 
 parameter_image = WhatsappSdk::Resource::ParameterObject.new(
   type: "image",
@@ -300,10 +302,16 @@ parameter_text = WhatsappSdk::Resource::ParameterObject.new(
   text: "I am a text"
 )
 
+parameter_location = WhatsappSdk::Resource::ParameterObject.new(
+  type: "location",
+  location: location
+)
+
 header_component.add_parameter(parameter_text)
 header_component.add_parameter(parameter_image)
 header_component.add_parameter(parameter_video)
 header_component.add_parameter(parameter_document)
+header_component.add_parameter(parameter_location)
 header_component.to_json
 
 body_component = WhatsappSdk::Resource::Component.new(

--- a/lib/whatsapp_sdk/resource/location.rb
+++ b/lib/whatsapp_sdk/resource/location.rb
@@ -1,0 +1,49 @@
+module WhatsappSdk
+  module Resource
+    class Location
+      extend T::Sig
+
+      # Returns the latitude of the location.
+      #
+      # @returns latitude [Float].
+      sig { returns(T.nilable(Float)) }
+      attr_accessor :latitude
+
+      # Returns the longitude of the location.
+      #
+      # @returns longitude [Float].
+      sig { returns(T.nilable(Float)) }
+      attr_accessor :longitude
+
+      # Returns the name of the location.
+      #
+      # @returns name [String].
+      sig { returns(T.nilable(String)) }
+      attr_accessor :name
+
+      # Returns the address of the location.
+      #
+      # @returns address [String].
+      sig { returns(T.nilable(String)) }
+      attr_accessor :address
+
+      sig { params(latitude: Float, longitude: Float, name: String, address: String).void }
+      def initialize(latitude:, longitude:, name:, address:)
+        @latitude = latitude
+        @longitude = longitude
+        @name = name
+        @address = address
+      end
+
+      sig { returns(T::Hash[T.untyped, T.untyped]) }
+      def to_json
+        {
+          latitude: latitude,
+          longitude: longitude,
+          name: name,
+          address: address
+        }
+      end
+    end
+  end
+end

--- a/lib/whatsapp_sdk/resource/parameter_object.rb
+++ b/lib/whatsapp_sdk/resource/parameter_object.rb
@@ -38,6 +38,7 @@ module WhatsappSdk
           Image = new("image")
           Document = new("document")
           Video = new("video")
+          Location = new("location")
         end
       end
 
@@ -79,13 +80,20 @@ module WhatsappSdk
       sig { returns(T.nilable(Media)) }
       attr_accessor :video
 
+      # Returns location if the parameter object type is location
+      #
+      # @returns location [Location]
+      sig { returns(T.nilable(Location)) }
+      attr_accessor :location
+
       sig do
         params(
           type: T.any(Type, String), text: T.nilable(String), currency: T.nilable(Currency),
-          date_time: T.nilable(DateTime), image: T.nilable(Media), document: T.nilable(Media), video: T.nilable(Media)
+          date_time: T.nilable(DateTime), image: T.nilable(Media), document: T.nilable(Media), video: T.nilable(Media),
+          location: T.nilable(Location)
         ).void
       end
-      def initialize(type:, text: nil, currency: nil, date_time: nil, image: nil, document: nil, video: nil)
+      def initialize(type:, text: nil, currency: nil, date_time: nil, image: nil, document: nil, video: nil, location: nil)
         @type = T.let(deserialize_type(type), Type)
         @text = text
         @currency = currency
@@ -93,6 +101,7 @@ module WhatsappSdk
         @image = image
         @document = document
         @video = video
+        @location = location
         validate
       end
 
@@ -112,6 +121,8 @@ module WhatsappSdk
                                         T.must(document).to_json
                                       when "video"
                                         T.must(video).to_json
+                                      when "location"
+                                        T.must(location).to_json
                                       else
                                         raise "Invalid type: #{type}"
                                       end
@@ -149,7 +160,8 @@ module WhatsappSdk
           [Type::DateTime, date_time],
           [Type::Image, image],
           [Type::Document, document],
-          [Type::Video, video]
+          [Type::Video, video],
+          [Type::Location, location]
         ].each do |type_b, value|
           next unless type == type_b
 

--- a/test/whatsapp/api/messages_test.rb
+++ b/test/whatsapp/api/messages_test.rb
@@ -579,6 +579,7 @@ module WhatsappSdk
         currency = Resource::Currency.new(code: "USD", amount: 1000, fallback_value: "1000")
         date_time = Resource::DateTime.new(fallback_value: "2020-01-01T00:00:00Z")
         image = Resource::Media.new(type: Resource::Media::Type::Image, link: "http(s)://URL")
+        location = Resource::Location.new(latitude: 25.779510, longitude: -80.338631, name: "miami store", address: "820 nw 87th ave, miami, fl")
 
         parameter_image = Resource::ParameterObject.new(
           type: Resource::ParameterObject::Type::Image, image: image
@@ -591,6 +592,10 @@ module WhatsappSdk
         )
         parameter_date_time = Resource::ParameterObject.new(
           type: Resource::ParameterObject::Type::DateTime, date_time: date_time
+        )
+        parameter_location = Resource::ParameterObject.new(
+          type: Resource::ParameterObject::Type::Location,
+          location: location
         )
 
         header_component = Resource::Component.new(
@@ -621,6 +626,11 @@ module WhatsappSdk
             Resource::ButtonParameter.new(type: Resource::ButtonParameter::Type::Payload,
                                           payload: "PAYLOAD")
           ]
+        )
+
+        location_component = Resource::Component.new(
+          type: Resource::Component::Type::Header,
+          parameters: [parameter_location]
         )
 
         @messages_api.expects(:send_request).with(
@@ -689,6 +699,20 @@ module WhatsappSdk
                       payload: "PAYLOAD"
                     }
                   ]
+                },
+                {
+                  type: "header",
+                  parameters: [
+                    {
+                      type: "location",
+                      location: {
+                        latitude: 25.779510,
+                        longitude: -80.338631,
+                        name: "miami store",
+                        address: "820 nw 87th ave, miami, fl"
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -698,7 +722,7 @@ module WhatsappSdk
 
         message_response = @messages_api.send_template(
           sender_id: 123_123, recipient_number: 12_345_678, name: "hello_world", language: "en_US",
-          components: [header_component, body_component, button_component1, button_component2]
+          components: [header_component, body_component, button_component1, button_component2, location_component]
         )
 
         assert_mock_response(valid_contacts, valid_messages, message_response)

--- a/test/whatsapp/resource/location_test.rb
+++ b/test/whatsapp/resource/location_test.rb
@@ -1,0 +1,17 @@
+# typed: true
+# frozen_string_literal: true
+require "test_helper"
+require "resource/location"
+
+module WhatsappSdk
+  module Resource
+    module Resource
+      class LocationTest < Minitest::Test
+        def test_to_json
+          location = Location.new(latitude: 25.779510, longitude: -80.338631, name: "Miami Store", address: "820 NW 87th Ave, Miami, FL")
+          assert_equal({ latitude: 25.779510, longitude: -80.338631, name: "Miami Store", address: "820 NW 87th Ave, Miami, FL" }, location.to_json)
+        end
+      end
+    end
+  end
+end

--- a/test/whatsapp/resource/parameter_object_test.rb
+++ b/test/whatsapp/resource/parameter_object_test.rb
@@ -6,6 +6,7 @@ require 'resource/parameter_object'
 require 'resource/media'
 require 'resource/date_time'
 require 'resource/currency'
+require 'resource/location'
 require 'error'
 require 'resource/errors'
 
@@ -21,11 +22,13 @@ module WhatsappSdk
           @video_media = Media.new(type: Media::Type::Video, id: "123")
           @currency = Currency.new(code: "USD", amount: 1000, fallback_value: "USD")
           @date_time = DateTime.new(fallback_value: "2020-01-01T00:00:00Z")
+          @location = Location.new(latitude: 25.779510, longitude: -80.338631, name: "Miami Store", address: "820 NW 87th Ave, Miami, FL")
         end
 
         [
           ParameterObject::Type::Text, ParameterObject::Type::Currency, ParameterObject::Type::DateTime,
-          ParameterObject::Type::Image, ParameterObject::Type::Document, ParameterObject::Type::Video
+          ParameterObject::Type::Image, ParameterObject::Type::Document, ParameterObject::Type::Video,
+          ParameterObject::Type::Location
         ].each do |type|
           define_method(
             "test_raise_an_error_when_type_is_#{type.serialize}_but_the_attribute_#{type.serialize}_is_not_passed"
@@ -54,6 +57,7 @@ module WhatsappSdk
           ParameterObject.new(type: ParameterObject::Type::Image, image: @image_media)
           ParameterObject.new(type: ParameterObject::Type::Video, video: @video_media)
           ParameterObject.new(type: ParameterObject::Type::Document, document: @document_media)
+          ParameterObject.new(type: ParameterObject::Type::Location, location: @location)
         end
 
         def test_to_json
@@ -97,6 +101,21 @@ module WhatsappSdk
           assert_equal(
             { type: "date_time", date_time: { fallback_value: @date_time.fallback_value } },
             parameter_date_time.to_json
+          )
+
+          parameter_location = ParameterObject.new(type: ParameterObject::Type::Location, location: @location)
+
+          assert_equal(
+            {
+              type: "location",
+              location: {
+                latitude: @location.latitude,
+                longitude: @location.longitude,
+                name: @location.name,
+                address: @location.address
+              }
+            },
+            parameter_location.to_json
           )
         end
       end


### PR DESCRIPTION
This PR
- Creates a `Location` resource
- Adds a new `Location` type to the `ParameterObject` class

Example of how to send an existing template with a Location Header

```rb
# Creates Location Object resource [Location Object](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#location-object)
location = WhatsappSdk::Resource::Location.new(
  latitude: 25.779510,
  longitude: -80.338631,
  name: "My Miami Store",
  address: "820 NW 87th Ave, Miami, FL"
)
# Creates a Location Parameter Object
location_parameter = WhatsappSdk::Resource::ParameterObject.new(type: "location", location: location)

# Creates a Location Component
location_component = WhatsappSdk::Resource::Component.new(
  type: WhatsappSdk::Resource::Component::Type::Header,
  parameters: [location_parameter]
)

# Sends an existing template with a Location Component
messages_api.send_template(
  sender_id: 123,
  recipient_number: 123,
  name: "location_test",
  language: "en_US",
  components: [location_component]
)
```

[Location Object reference](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#location-object)
[Sending an existing template with location headers docs](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates/#example-request)

closes #85 