### PR TITLE
Implement a better API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
+- Implement a Better API for calling the Cloud API [156](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/156)
 - Used [VCR gem]() for tests @igacio-chiazzo [153](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/153)
+- Added support for  API v20.0 and v21.0 @guizaols [152](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/152)
 - Increased minimum required Ruby version to 2.7.0 @ignacio-chiazzo [151](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/151)
 
 # v 0.13.0

--- a/README.md
+++ b/README.md
@@ -141,10 +141,14 @@ Check the [example.rb file](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk
 
 ```ruby
 # Get list of templates
-client.templates.templates(business_id: BUSINESS_ID)
+client.templates.list(business_id: BUSINESS_ID)
+
+# Get Message Template Namespace
+# The message template namespace is required to send messages using the message templates.
+client.templates.get_message_template_namespace(business_id: BUSINESS_ID)
 
 # Create a template
-new_template = client.templates.create(
+client.templates.create(
   business_id: BUSINESS_ID, name: "seasonal_promotion", language: "en_US", category: "MARKETING",
   components_json: components_json, allow_category_change: true
 )
@@ -160,7 +164,7 @@ client.templates.delete(business_id: BUSINESS_ID, name: "my_name") # delete by n
 
 ```ruby
 # Get the details of your business
-business_profile = client.business_profiles.details(123456)
+client.business_profiles.get(phone_number_id)
 
 # Update the details of your business
 client.business_profiles.update(phone_number_id: SENDER_ID, params: { about: "A very cool business" } )
@@ -173,10 +177,10 @@ client.business_profiles.update(phone_number_id: SENDER_ID, params: { about: "A 
 
 ```ruby
 # Get the list of phone numbers registered
-client.phone_numbers.registered_numbers(business_id)
+client.phone_numbers.list(business_id)
 
 # Get the a phone number by id
-client.phone_numbers.registered_numbers(phone_number_id)
+client.phone_numbers.get(phone_number_id)
 
 # Register a phone number
 client.phone_numbers.register_number(phone_number_id, pin)

--- a/example.rb
+++ b/example.rb
@@ -65,7 +65,7 @@ client = WhatsappSdk::Api::Client.new
 puts "\n\n ------------------ Testing Templates API ------------------------"
 
 ## Get list of templates
-templates = client.templates.templates(business_id: BUSINESS_ID)
+templates = client.templates.list(business_id: BUSINESS_ID)
 puts "GET Templates list : #{print_data_or_error(templates, templates.data&.templates.map { |r| r.template.name })}"
 
 ## Get message templates namespace
@@ -139,7 +139,7 @@ puts "Delete template by id: #{print_data_or_error(delete_template, delete_templ
 ############################## Business API ##############################
 puts "\n\n\n ------------------ Testing Business API -----------------------"
 
-business_profile = client.business_profiles.details(SENDER_ID)
+business_profile = client.business_profiles.get(SENDER_ID)
 puts "DELETE Business Profile by id: #{print_data_or_error(delete_template, business_profile.data&.about) }"
 
 updated_bp = client.business_profiles.update(phone_number_id: SENDER_ID, params: { about: "A very cool business" } )
@@ -148,10 +148,10 @@ puts "UPDATE Business Profile by id: #{print_data_or_error(updated_bp, updated_b
 
 ############################## Phone Numbers API ##############################
 puts "\n\n\n ------------------ Testing Phone Numbers API -----------------------"
-registered_number = client.phone_numbers.registered_number(SENDER_ID)
+registered_number = client.phone_numbers.get(SENDER_ID)
 puts "GET Registered number: #{print_data_or_error(registered_number, registered_number.data&.id)}"
 
-registered_numbers = client.phone_numbers.registered_numbers(BUSINESS_ID)
+registered_numbers = client.phone_numbers.list(BUSINESS_ID)
 puts "GET Registered numbers: #{print_data_or_error(registered_number, registered_numbers.data&.phone_numbers.map(&:id))}"
 
 ############################## Media API ##############################

--- a/example.rb
+++ b/example.rb
@@ -33,7 +33,7 @@ if ACCESS_TOKEN == "<TODO replace>"
   exit
 end
 
-puts "\n\n\n\n\n\n ***************    Starting calling the Cloud API    *************** \n"
+puts "\n\n\n\ ------------------ Starting calling the Cloud API -------------------\n"
 
 ################# Initialize Client #################
 WhatsappSdk.configure do |config|
@@ -41,11 +41,11 @@ WhatsappSdk.configure do |config|
 end
 
 ################# HELPERS ########################
-def print_message_sent(message_response)
+def print_message_sent(message_response, type = "")
   if message_response.ok?
-    puts "Message sent to: #{message_response.data.contacts.first.input}"
+    puts "Message #{type} sent to: #{message_response.data.contacts.first.input}"
   else
-    puts "Error: #{message_response.error&.to_s}"
+    puts "Error: #{message_response.error.message}"
   end
 end
 
@@ -57,21 +57,19 @@ def print_data_or_error(response, identifier)
   return identifier
 end
 ##################################################
+client = WhatsappSdk::Api::Client.new
 
 
-medias_api = WhatsappSdk::Api::Medias.new
-messages_api = WhatsappSdk::Api::Messages.new
-phone_numbers_api = WhatsappSdk::Api::PhoneNumbers.new
-business_profile_api = WhatsappSdk::Api::BusinessProfile.new
-templates_api = WhatsappSdk::Api::Templates.new
 
 ############################## Templates API ##############################
+puts "\n\n ------------------ Testing Templates API ------------------------"
+
 ## Get list of templates
-templates = templates_api.templates(business_id: BUSINESS_ID)
+templates = client.templates.templates(business_id: BUSINESS_ID)
 puts "GET Templates list : #{print_data_or_error(templates, templates.data&.templates.map { |r| r.template.name })}"
 
 ## Get message templates namespace
-template_namespace = templates_api.get_message_template_namespace(business_id: BUSINESS_ID)
+template_namespace = client.templates.get_message_template_namespace(business_id: BUSINESS_ID)
 puts "GET template by namespace: #{print_data_or_error(template_namespace, template_namespace.data&.id)}"
 
 # Create a template
@@ -104,7 +102,7 @@ components_json = [
   }
 ]
 
-new_template = templates_api.create(
+new_template = client.templates.create(
   business_id: BUSINESS_ID, name: "seasonal_promotion", language: "ka", category: "MARKETING",
   components_json: components_json, allow_category_change: true
 )
@@ -124,171 +122,200 @@ components_json = [
     ]
   }
 ]
-updated_template = templates_api.update(template_id: "1624560287967996", category: "UTILITY")
-puts "UPDATE template by id: #{print_data_or_error(updated_template, updated_template.data&.id)}"
+
+if new_template&.data&.id
+  updated_template = client.templates.update(template_id: new_template&.data.id, category: "UTILITY")
+  puts "UPDATE template by id: #{print_data_or_error(updated_template, updated_template.data&.id)}"
+end
 
 ## Delete a template
-delete_template = templates_api.delete(business_id: BUSINESS_ID, name: "seasonal_promotion") # delete by name
-puts "DELETE template by id: #{print_data_or_error(delete_template, delete_template.data&.id) }"
-# templates_api.delete(business_id: BUSINESS_ID, name: "name2", hsm_id: "243213188351928") # delete by name and id
+delete_template = client.templates.delete(business_id: BUSINESS_ID, name: "seasonal_promotion") # delete by name
+puts "Delete template by id: #{print_data_or_error(delete_template, delete_template.data&.id) }"
+
+# client.templates.delete(business_id: BUSINESS_ID, name: "name2", hsm_id: "243213188351928") # delete by name and id
+
+
 
 ############################## Business API ##############################
-business_profile = business_profile_api.details(SENDER_ID)
+puts "\n\n\n ------------------ Testing Business API -----------------------"
+
+business_profile = client.business_profiles.details(SENDER_ID)
 puts "DELETE Business Profile by id: #{print_data_or_error(delete_template, business_profile.data&.about) }"
 
-updated_bp = business_profile_api.update(phone_number_id: SENDER_ID, params: { about: "A very cool business" } )
+updated_bp = client.business_profiles.update(phone_number_id: SENDER_ID, params: { about: "A very cool business" } )
 puts "UPDATE Business Profile by id: #{print_data_or_error(updated_bp, updated_bp.data&.success?) }"
 
+
 ############################## Phone Numbers API ##############################
-registered_number = phone_numbers_api.registered_number(SENDER_ID)
+puts "\n\n\n ------------------ Testing Phone Numbers API -----------------------"
+registered_number = client.phone_numbers.registered_number(SENDER_ID)
 puts "GET Registered number: #{print_data_or_error(registered_number, registered_number.data&.id)}"
 
-registered_numbers = phone_numbers_api.registered_numbers(BUSINESS_ID)
+registered_numbers = client.phone_numbers.registered_numbers(BUSINESS_ID)
 puts "GET Registered numbers: #{print_data_or_error(registered_number, registered_numbers.data&.phone_numbers.map(&:id))}"
 
 ############################## Media API ##############################
-
+puts "\n\n\n ------------------ Testing Media API"
 ##### Image #####
 # upload a Image
-uploaded_media = medias_api.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/whatsapp.png", type: "image/png")
-puts "Uploaded media id: #{print_data_or_error(uploaded_media, uploaded_media.data&.id)}"
+uploaded_media = client.media.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/whatsapp.png", type: "image/png")
+puts "Uploaded image id: #{print_data_or_error(uploaded_media, uploaded_media.data&.id)}"
 
 # get a media Image
 if uploaded_media.data&.id
-  media = medias_api.media(media_id: 1753306975419607)
-  puts "GET Media id: #{print_data_or_error(media, media.data&.id)}"
+  image = client.media.get(media_id: uploaded_media.data&.id)
+  puts "GET image id: #{print_data_or_error(image, image.data&.id)}"
 
   # download media Image
-  download_image = medias_api.download(url: media.data.url, file_path: 'test/fixtures/assets/downloaded_image.png', media_type: "image/png")
-  puts "Downloaded: #{print_data_or_error(download_image, download_image.data.success?)}"
+  download_image = client.media.download(url: image.data.url, file_path: 'test/fixtures/assets/downloaded_image.png', media_type: "image/png")
+  puts "Downloaded Image: #{print_data_or_error(download_image, download_image.data.success?)}"
 
+  uploaded_media = client.media.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/whatsapp.png", type: "image/png")
   # delete a media
-  deleted_media = medias_api.delete(media_id: media.data.id)
-  puts "DELETE: #{print_data_or_error(deleted_media, deleted_media.data.success?)}"
+  deleted_media = client.media.delete(media_id: uploaded_media.data.id)
+  puts "Delete image: #{print_data_or_error(deleted_media, deleted_media.data.success?)}"
 else
   puts "No media to download and delete"
 end
 
 #### Video ####
 # upload a video
-uploaded_media = medias_api.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/riquelme.mp4", type: "video/mp4")
-puts "Uploaded media id: #{print_data_or_error(uploaded_media, uploaded_media.data&.id)}"
+uploaded_video = client.media.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/riquelme.mp4", type: "video/mp4")
+puts "Uploaded video: #{print_data_or_error(uploaded_media, uploaded_video.data&.id)}"
 
-media = medias_api.media(media_id: "535689082735659")
+video = client.media.get(media_id: uploaded_video.data&.id)
 
 # upload a video
-uploaded_video = medias_api.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/riquelme.mp4", type: "video/mp4")
-puts "Uploaded media id: #{print_data_or_error(uploaded_media, uploaded_media.data&.id)}"
-
-media = medias_api.media(media_id: "535689082735659")
+uploaded_video = client.media.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/riquelme.mp4", type: "video/mp4")
+puts "Uploaded video id: #{print_data_or_error(uploaded_media, video.data&.id)}"
 
 #### Audio ####
 # upload an audio
-uploaded_media = medias_api.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/downloaded_audio.ogg", type: "audio/ogg")
-puts "Uploaded media id: #{print_data_or_error(uploaded_media, uploaded_media.data&.id)}"
+audio_response = client.media.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/downloaded_audio.ogg", type: "audio/ogg")
+puts "Uploaded audio id: #{print_data_or_error(audio_response, audio_response.data&.id)}"
 
-if uploaded_media.data&.id
-  media_id = uploaded_media.data&.id
-  puts "Uploaded media id: #{media_id}"
+if audio_response.data&.id
+  audio_id = audio_response.data&.id
+  # get a media audio
+  audio = client.media.get(media_id: audio_id)
+  puts "GET Audio id: #{print_data_or_error(audio, audio_id)}"
 
   # get a media audio
-  media = medias_api.media(media_id: media_id)
-  puts "GET Media id: #{print_data_or_error(media, media_id)}"
-
-  # get a media audio
-  audio_link = media.data.url
-  download_image = medias_api.download(url: audio_link, file_path: 'test/fixtures/assets/downloaded_audio2.ogg', media_type: "audio/ogg")
-  puts "Download Media Audio: #{print_data_or_error(download_image, download_image.data.success?)}"
+  audio_link = audio.data.url
+  download_image = client.media.download(url: audio_link, file_path: 'test/fixtures/assets/downloaded_audio2.ogg', media_type: "audio/ogg")
+  puts "Download Audio: #{print_data_or_error(download_image, download_image.data.success?)}"
 end
 
+# upload a document
+document_response = client.media.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/document.pdf", type: "application/pdf")
+puts "Uploaded document id: #{print_data_or_error(document_response, document_response.data&.id)}"
+
+document = client.media.get(media_id: document_response.data&.id)
+puts "GET document id: #{print_data_or_error(document, document.data&.id)}"
+
+# upload a sticker
+sticker_response = client.media.upload(sender_id: SENDER_ID, file_path: "test/fixtures/assets/sticker.webp", type: "image/webp")
+puts "Uploaded sticker id: #{print_data_or_error(sticker_response, sticker_response.data&.id)}"
+
+sticker = client.media.get(media_id: sticker_response.data&.id)
+puts "GET Sticker id: #{print_data_or_error(sticker, sticker.data&.id)}"
+
+
+
 ############################## Messages API ##############################
+puts "\n\n\n ------------------ Testing Messages API -----------------------"
 
 ######### SEND A TEXT MESSAGE
-message_sent = messages_api.send_text(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
+message_sent = client.messages.send_text(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
                                       message: "Hey there! it's Whatsapp Ruby SDK")
-print_message_sent(message_sent)
+print_message_sent(message_sent, "text")
 
 ######### React to a message
-message_id = message_sent.data.messages.first.id
-reaction_1_sent = messages_api.send_reaction(
+message_id = message_sent.data&.messages.first.id
+reaction_1_sent = client.messages.send_reaction(
   sender_id: SENDER_ID,
   recipient_number: RECIPIENT_NUMBER,
   message_id: message_id,
   emoji: "\u{1f550}"
-  )
+) if message_id
 
-reaction_2_sent = messages_api.send_reaction(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
-                                             message_id: message_id, emoji: "⛄️")
+reaction_2_sent = client.messages.send_reaction(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
+                                             message_id: message_id, emoji: "⛄️") if message_id
 puts "Message Reaction 1: #{print_data_or_error(reaction_1_sent, reaction_1_sent.data&.messages.first&.id)}"
 puts "Message Reaction 2: #{print_data_or_error(reaction_2_sent, reaction_2_sent.data&.messages.first&.id)}"
 
 ######### Reply to a message
 message_to_reply_id = message_sent.data.messages.first.id
-reply = messages_api.send_text(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, message: "I'm a reply",
+reply = client.messages.send_text(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, message: "I'm a reply",
                                message_id: message_to_reply_id)
-print_message_sent(reply)
+print_message_sent(reply, "reply")
 
 ######### Send location
-location_sent = messages_api.send_location(
+
+location_sent = client.messages.send_location(
   sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
   longitude: -75.6898604, latitude: 45.4192206, name: "Ignacio", address: "My house"
 )
-print_message_sent(location_sent)
+print_message_sent(location_sent, "location")
 
 ######### READ A MESSAGE
-# messages_api.read_message(sender_id: SENDER_ID, message_id: msg_id)
+# client.messages.read_message(sender_id: SENDER_ID, message_id: msg_id)
 
 ######### SEND AN IMAGE
 # Send an image with a link
-if media.data&.id
-  image_sent = messages_api.send_image(
-    sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: media.data.url, caption: "Ignacio Chiazzo Profile"
+if image.data&.id
+  image_sent = client.messages.send_image(
+    sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: image.data.url, caption: "Ignacio Chiazzo Profile"
   )
-  print_message_sent(image_sent)
+  print_message_sent(image_sent, "image via url")
 
   # Send an image with an id
-  messages_api.send_image(
-    sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, image_id: media.data.id, caption: "Ignacio Chiazzo Profile"
+  client.messages.send_image(
+    sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, image_id: image.data.id, caption: "Ignacio Chiazzo Profile"
   )
-  print_message_sent(image_sent)
+  print_message_sent(image_sent, "image via id")
 end
 
 ######### SEND AUDIOS
 ## with a link
-audio_sent = messages_api.send_audio(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: "audio_link")
-print_message_sent(audio_sent)
+audio_sent = client.messages.send_audio(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: audio.data.url)
+print_message_sent(audio_sent, "audio via url")
 
 ## with an audio id
-audio_sent = messages_api.send_audio(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, audio_id: "1234")
-print_message_sent(audio_sent)
+audio_sent = client.messages.send_audio(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, audio_id: audio.data.id)
+print_message_sent(audio_sent, "audio via id")
 
 ######### SEND DOCUMENTS
 ## with a link
-document_sent = messages_api.send_document(
-  sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: "document_link", caption: "Ignacio Chiazzo"
-)
-print_message_sent(document_sent)
+if document.data&.id
+  document_sent = client.messages.send_document(
+    sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: document.data&.url, caption: "Ignacio Chiazzo"
+  )
+  print_message_sent(document_sent, "document via url")
 
-## with a document id
-document_sent = messages_api.send_document(
-  sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, document_id: "1234", caption: "Ignacio Chiazzo"
-)
-print_message_sent(document_sent)
+  ## with a document id
+  document_sent = client.messages.send_document(
+    sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, document_id: document.data&.id, caption: "Ignacio Chiazzo"
+  ) # modify
+  print_message_sent(document_sent, "document via id")
+end
 
 ######### SEND STICKERS
-## with a link
-sticker_sent = messages_api.send_sticker(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: "link")
-print_message_sent(sticker_sent)
+if sticker.data&.id
+  ## with a link
+  sticker_sent = client.messages.send_sticker(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, link: sticker.data.url)
+  print_message_sent(sticker_sent, "sticker via url")
 
-## with a sticker_id
-sticker_sent = messages_api.send_sticker(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, sticker_id: "1234")
-print_message_sent(sticker_sent)
+  ## with a sticker_id
+  sticker_sent = client.messages.send_sticker(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, sticker_id: sticker.data.id)
+  print_message_sent(sticker_sent, "sticker via id")
+end
 
 ######### SEND A TEMPLATE
 # Note: The template must have been created previously.
 
 # Send a template with no component
-response_with_object = messages_api.send_template(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
+response_with_object = client.messages.send_template(sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
                                                   name: "hello_world", language: "en_US", components: [])
 puts response_with_object
 
@@ -361,7 +388,7 @@ button_component_2 = WhatsappSdk::Resource::Component.new(
 )
 
 # Send a template with component_json
-response_with_json = messages_api.send_template(
+response_with_json = client.messages.send_template(
   sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER, name: "hello_world", language: "en_US",
   components_json: [
     {
@@ -418,7 +445,7 @@ interactive_reply_buttons = WhatsappSdk::Resource::Interactive.new(
   action: interactive_action
 )
 
-messages_api.send_interactive_reply_buttons(
+client.messages.send_interactive_reply_buttons(
   sender_id: SENDER_ID, recipient_number: RECIPIENT_NUMBER,
   interactive: interactive_reply_buttons
 )

--- a/lib/whatsapp_sdk/api/business_profile.rb
+++ b/lib/whatsapp_sdk/api/business_profile.rb
@@ -23,7 +23,7 @@ module WhatsappSdk
       #
       # @param phone_number_id [Integer] Phone Number Id.
       # @return [Api::Response] Response object.
-      def details(phone_number_id, fields: nil)
+      def get(phone_number_id, fields: nil)
         fields = if fields
                    fields.join(',')
                  else
@@ -39,6 +39,11 @@ module WhatsappSdk
           response: response,
           data_class_type: Api::Responses::BusinessProfileDataResponse
         )
+      end
+
+      def details(phone_number_id, fields: nil)
+        warn "[DEPRECATION] `details` is deprecated. Please use `get` instead."
+        get(phone_number_id, fields: fields)
       end
 
       # Update the details of business profile.

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -14,7 +14,7 @@ module WhatsappSdk
       ].freeze
 
       def initialize(
-        access_token,
+        access_token = WhatsappSdk.configuration.access_token,
         api_version = ApiConfiguration::DEFAULT_API_VERSION,
         logger = nil,
         logger_options = {}
@@ -25,6 +25,26 @@ module WhatsappSdk
 
         validate_api_version(api_version)
         @api_version = api_version
+      end
+
+      def media
+        @media ||= WhatsappSdk::Api::Medias.new
+      end
+
+      def messages
+        @messages ||= WhatsappSdk::Api::Messages.new
+      end
+
+      def phone_numbers
+        @phone_numbers ||= WhatsappSdk::Api::PhoneNumbers.new
+      end
+
+      def business_profiles
+        @business_profiles ||= WhatsappSdk::Api::BusinessProfile.new
+      end
+
+      def templates
+        @templates ||= WhatsappSdk::Api::Templates.new
       end
 
       def send_request(endpoint: "", full_url: nil, http_method: "post", params: {}, headers: {}, multipart: false)

--- a/lib/whatsapp_sdk/api/medias.rb
+++ b/lib/whatsapp_sdk/api/medias.rb
@@ -38,7 +38,7 @@ module WhatsappSdk
       #
       # @param media_id [String] Media Id.
       # @return [Api::Response] Response object.
-      def media(media_id:)
+      def get(media_id:)
         response = send_request(
           http_method: "get",
           endpoint: "/#{media_id}"
@@ -48,6 +48,11 @@ module WhatsappSdk
           response: response,
           data_class_type: Api::Responses::MediaDataResponse
         )
+      end
+
+      def media(media_id:)
+        warn "[DEPRECATION] `media` is deprecated. Please use `get` instead."
+        get(media_id: media_id)
       end
 
       # Download Media by URL.

--- a/lib/whatsapp_sdk/api/phone_numbers.rb
+++ b/lib/whatsapp_sdk/api/phone_numbers.rb
@@ -16,7 +16,7 @@ module WhatsappSdk
       #
       # @param business_id [Integer] Business Id.
       # @return [Api::Response] Response object.
-      def registered_numbers(business_id)
+      def list(business_id)
         response = send_request(
           http_method: "get",
           endpoint: "#{business_id}/phone_numbers?fields=#{DEFAULT_FIELDS}"
@@ -28,11 +28,11 @@ module WhatsappSdk
         )
       end
 
-      # Get the registered number id.
+      # Get the registered number.
       #
       # @param phone_number_id [Integer] The registered number we want to retrieve.
       # @return [Api::Response] Response object.
-      def registered_number(phone_number_id)
+      def get(phone_number_id)
         response = send_request(
           http_method: "get",
           endpoint: "#{phone_number_id}?fields=#{DEFAULT_FIELDS}"
@@ -77,6 +77,17 @@ module WhatsappSdk
           response: response,
           data_class_type: Api::Responses::PhoneNumberDataResponse
         )
+      end
+
+      # deprecated methods
+      def registered_numbers(business_id)
+        warn "[DEPRECATION] `registered_numbers` is deprecated. Please use `list` instead."
+        list(business_id)
+      end
+
+      def registered_number(phone_number_id)
+        warn "[DEPRECATION] `registered_number` is deprecated. Please use `get` instead."
+        get(phone_number_id)
       end
     end
   end

--- a/lib/whatsapp_sdk/api/request.rb
+++ b/lib/whatsapp_sdk/api/request.rb
@@ -1,5 +1,6 @@
 # typed: true
 # frozen_string_literal: true
+
 require_relative "../../whatsapp_sdk"
 
 module WhatsappSdk

--- a/lib/whatsapp_sdk/api/request.rb
+++ b/lib/whatsapp_sdk/api/request.rb
@@ -1,5 +1,6 @@
 # typed: true
 # frozen_string_literal: true
+require_relative "../../whatsapp_sdk"
 
 module WhatsappSdk
   module Api

--- a/lib/whatsapp_sdk/api/templates.rb
+++ b/lib/whatsapp_sdk/api/templates.rb
@@ -75,7 +75,7 @@ module WhatsappSdk
       # @param business_id [Integer] The business ID.
       # @param limit [Integer] Optional. Number of templates to return in a single page.
       # @return [Response] Response object.
-      def templates(business_id:, limit: 100)
+      def list(business_id:, limit: 100)
         params = {}
         params["limit"] = limit if limit
 
@@ -90,6 +90,11 @@ module WhatsappSdk
           data_class_type: Responses::TemplatesDataResponse,
           error_class_type: Responses::GenericErrorResponse
         )
+      end
+
+      def templates(business_id:)
+        warn "[DEPRECATION] `templates` is deprecated. Please use `list` instead."
+        list(business_id: business_id)
       end
 
       # Get Message Template Namespace

--- a/test/whatsapp/api/business_profile_test.rb
+++ b/test/whatsapp/api/business_profile_test.rb
@@ -15,26 +15,26 @@ module WhatsappSdk
         @business_profile_api = BusinessProfile.new(client)
       end
 
-      def test_details_handles_error_response
+      def test_get_handles_error_response
         VCR.use_cassette('business_profile/details_handles_error_response') do
-          response = @business_profile_api.details(123_123)
+          response = @business_profile_api.get(123_123)
           assert_unsupported_request_error("get", response, "123123", "AYMXgC3SR8dC_HM7lrwoPOZ")
         end
       end
 
-      def test_details_accepts_fields
+      def test_get_accepts_fields
         fields = %w[vertical]
         VCR.use_cassette('business_profile/details_accepts_fields') do
-          response = @business_profile_api.details(107_878_721_936_019, fields: fields)
+          response = @business_profile_api.get(107_878_721_936_019, fields: fields)
 
           assert_ok_response(response)
           assert_equal(%w[vertical messaging_product], response.raw_response["data"][0].keys)
         end
       end
 
-      def test_details_sends_all_fields_by_default
+      def test_get_sends_all_fields_by_default
         VCR.use_cassette('business_profile/details_sends_all_fields_by_default') do
-          response = @business_profile_api.details(107_878_721_936_019)
+          response = @business_profile_api.get(107_878_721_936_019)
 
           assert_business_details_response(
             {
@@ -51,9 +51,9 @@ module WhatsappSdk
         end
       end
 
-      def test_details_with_success_response
+      def test_get_with_success_response
         VCR.use_cassette('business_profile/details_with_success_response') do
-          response = @business_profile_api.details(107_878_721_936_019)
+          response = @business_profile_api.get(107_878_721_936_019)
 
           assert_business_details_response(
             {

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -122,10 +122,6 @@ module WhatsappSdk
         assert_equal(WhatsappSdk::Api::Templates, @client.templates.class)
       end
 
-      def test_users
-        assert_equal(WhatsappSdk::Api::Users, @client.users.class)
-      end
-
       private
 
       def stub_test_request(method_name, body: {}, headers: {}, response_status: 200, response_body: { success: true },

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -9,7 +9,9 @@ module WhatsappSdk
   module Api
     class ClientTest < Minitest::Test
       def setup(api_version: ApiConfiguration::DEFAULT_API_VERSION)
-        @client = Client.new('test_token', api_version)
+        @access_token = 'test_token'
+        @api_version = api_version
+        @client = Client.new(@access_token, @api_version)
       end
 
       def test_send_request_post_with_success_response
@@ -98,6 +100,30 @@ module WhatsappSdk
         # Validates whether the logger was configured into faraday or not
         middleware_handlers = faraday_middlewares(@client)
         refute_includes(middleware_handlers, Faraday::Response::Logger)
+      end
+
+      def test_media
+        assert_equal(WhatsappSdk::Api::Medias, @client.media.class)
+      end
+
+      def test_messages
+        assert_equal(WhatsappSdk::Api::Messages, @client.messages.class)
+      end
+
+      def test_phone_numbers
+        assert_equal(WhatsappSdk::Api::PhoneNumbers, @client.phone_numbers.class)
+      end
+
+      def test_business_profiles
+        assert_equal(WhatsappSdk::Api::BusinessProfile, @client.business_profiles.class)
+      end
+
+      def test_templates
+        assert_equal(WhatsappSdk::Api::Templates, @client.templates.class)
+      end
+
+      def test_users
+        assert_equal(WhatsappSdk::Api::Users, @client.users.class)
       end
 
       private

--- a/test/whatsapp/api/medias_test.rb
+++ b/test/whatsapp/api/medias_test.rb
@@ -17,16 +17,16 @@ module WhatsappSdk
         @sender_id = 107_878_721_936_019
       end
 
-      def test_media_handles_error_response
+      def test_get_handles_error_response
         VCR.use_cassette("medias/media_handles_error_response") do
-          response = @medias_api.media(media_id: "123_123")
+          response = @medias_api.get(media_id: "123_123")
           assert_unsupported_request_error("get", response, "123_123", "ATf5-CLoxGyJeSu2vrRDOZR")
         end
       end
 
-      def test_media_with_success_response
+      def test_get_with_success_response
         VCR.use_cassette("medias/media_with_success_response") do
-          response = @medias_api.media(media_id: "1761991787669262")
+          response = @medias_api.get(media_id: "1761991787669262")
 
           assert_media_response({
                                   url: "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=1761991787669262&ext=1728904986&hash=ATta-PkMyBz0aTF9b0CVDimLtAkAgpdXQa6t5x1KgUOu-Q",

--- a/test/whatsapp/api/phone_numbers_test.rb
+++ b/test/whatsapp/api/phone_numbers_test.rb
@@ -16,23 +16,23 @@ module WhatsappSdk
         @phone_numbers_api = PhoneNumbers.new(client)
       end
 
-      def test_registered_numbers_handles_error_response
+      def test_list_handles_error_response
         VCR.use_cassette('phone_numbers/registered_numbers_handles_error_response') do
-          response = @phone_numbers_api.registered_numbers(123_123)
+          response = @phone_numbers_api.list(123_123)
           assert_unsupported_request_error("get", response, "123123", "AFZgW89DkR0hLRFJP40NTd6")
         end
       end
 
-      def test_registered_numbers_with_success_response
+      def test_list_with_success_response
         VCR.use_cassette('phone_numbers/registered_numbers_with_success_response') do
-          response = @phone_numbers_api.registered_numbers(114_503_234_599_312)
+          response = @phone_numbers_api.list(114_503_234_599_312)
 
           expected_phone_numbers = [registered_phone_number]
           assert_phone_numbers_success_response(expected_phone_numbers, response)
         end
       end
 
-      def test_registered_numbers_sends_valid_params
+      def test_list_sends_valid_params
         @phone_numbers_api.expects(:send_request).with(
           http_method: "get",
           endpoint: "123123/phone_numbers?fields=#{PhoneNumbers::DEFAULT_FIELDS}"
@@ -43,24 +43,24 @@ module WhatsappSdk
           }
         )
 
-        @phone_numbers_api.registered_numbers(123_123)
+        @phone_numbers_api.list(123_123)
       end
 
-      def test_registered_number_handles_error_response
+      def test_get_handles_error_response
         VCR.use_cassette('phone_numbers/registered_number_handles_error_response') do
-          response = @phone_numbers_api.registered_number(123_123)
+          response = @phone_numbers_api.get(123_123)
           assert_unsupported_request_error("get", response, "123123", "AlicHjOpoShf8TV_iXRm1pW")
         end
       end
 
-      def test_registered_number_with_success_response
+      def test_get_with_success_response
         VCR.use_cassette('phone_numbers/registered_number_with_success_response') do
-          response = @phone_numbers_api.registered_number(107_878_721_936_019)
+          response = @phone_numbers_api.get(107_878_721_936_019)
           assert_phone_number_success_response(registered_phone_number, response)
         end
       end
 
-      def test_registered_number_sends_valid_params
+      def test_get_sends_valid_params
         @phone_numbers_api.expects(:send_request).with(
           http_method: "get",
           endpoint: "123123?fields=#{PhoneNumbers::DEFAULT_FIELDS}"
@@ -68,7 +68,7 @@ module WhatsappSdk
           { "data" => [registered_phone_number] }
         )
 
-        @phone_numbers_api.registered_number(123_123)
+        @phone_numbers_api.get(123_123)
       end
 
       def test_register_number_handles_error_response

--- a/test/whatsapp/api/templates_test.rb
+++ b/test/whatsapp/api/templates_test.rb
@@ -67,7 +67,7 @@ module WhatsappSdk
       ##### GET Templates
       def test_get_templates
         VCR.use_cassette('templates/get_templates') do
-          templates_response = @templates_api.templates(business_id: 114_503_234_599_312)
+          templates_response = @templates_api.list(business_id: 114_503_234_599_312)
           assert_ok_response(templates_response)
           assert_equal(Responses::TemplatesDataResponse, templates_response.data.class)
           assert_equal(25, templates_response.data.templates.size)
@@ -77,7 +77,7 @@ module WhatsappSdk
 
       def test_get_templates_when_an_error_is_returned
         VCR.use_cassette('templates/get_templates_when_an_error_is_returned') do
-          templates_response = @templates_api.templates(business_id: 123_456)
+          templates_response = @templates_api.list(business_id: 123_456)
           assert_unsupported_request_error("get", templates_response, "123456", "AhvemSTIjTs-WJikZKj0mLu")
         end
       end


### PR DESCRIPTION
Solves https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/issues/155

This PR introduces a new API to interact with the different API concerns. Instead of creating a new object per each area (media, messages, business_profiles etc) we can just call `client.` with the api name. 


Before: 

```ruby
  messages_api = WhatsappSdk::Api::Messages.new
  phone_numbers_api = WhatsappSdk::Api::PhoneNumbers.new
  business_profile_api = WhatsappSdk::Api::BusinessProfile.new
  templates_api = WhatsappSdk::Api::Templates.new

  messages_api.get 
  #...
  phone_numbers_api.registered_number ...
```

After: 

```
client.messages.send_text(....)

client.media.upload(....)

client.business_profiles.details
```

This PR also deprecates some methods:

|Concern| Before | After |
|-|-|-|
| Business Profile | `client.business_profiles.details` | `client.business_profiles.get`|
| Phone Numbers | `client.phone_numbers.registered_numbers` | `client.phone_numbers.list`|
| Phone Numbers | `client.phone_numbers.registered_number` | `client.phone_numbers.get`|
| Templates | `client.templates.templates` | `client.templates.list`|
| Media | `client.medias.media` | `client.medias.get`|

Note: I still maintain the old methods but raised a deprecated warning. I plan to remove them as part of 1.0.0.

To see the final API, see the README file. 
