### PR TITLE
Release version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+# v 1.0.0
 - Implement a Better response API [159](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/156)
 - Implement a Better API for calling the Cloud API [156](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/156)
 - Used [VCR gem]() for tests @igacio-chiazzo [153](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/153)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsapp_sdk (0.13.0)
+    whatsapp_sdk (1.0.0)
       faraday (~> 2)
       faraday-multipart (~> 1)
       zeitwerk (~> 2)
@@ -27,7 +27,7 @@ GEM
     method_source (1.0.0)
     minitest (5.16.1)
     mocha (1.14.0)
-    multipart-post (2.4.0)
+    multipart-post (2.4.1)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -68,7 +68,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.6.13)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   arm64-darwin-21

--- a/lib/whatsapp_sdk/version.rb
+++ b/lib/whatsapp_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WhatsappSdk
-  VERSION = "0.13.0"
+  VERSION = "1.0.0"
 end

--- a/test/whatsapp/version_test.rb
+++ b/test/whatsapp/version_test.rb
@@ -6,6 +6,6 @@ require 'version'
 
 class VersionTest < Minitest::Test
   def test_that_it_has_a_version_number
-    assert_equal("0.13.0", WhatsappSdk::VERSION)
+    assert_equal("1.0.0", WhatsappSdk::VERSION)
   end
 end


### PR DESCRIPTION
This version contains major changes, particularly on the API shape: 

- Implement a Better response API [159](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/156)
- Implement a Better API for calling the Cloud API [156](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/156)
- Used [VCR gem]() for tests @igacio-chiazzo [153](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/153)
- Added support for  API v20.0 and v21.0 @guizaols [152](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/152)
- Increased minimum required Ruby version to 2.7.0 @ignacio-chiazzo [151](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/151)
