### PR TITLE
Hotfix: require error

### DIFF
--- a/lib/whatsapp_sdk/resource/errors.rb
+++ b/lib/whatsapp_sdk/resource/errors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "../error"
+require_relative "../error"
 # require "lib/whatsapp_sdk/error"
 
 module WhatsappSdk

--- a/lib/whatsapp_sdk/resource/errors.rb
+++ b/lib/whatsapp_sdk/resource/errors.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../error"
-# require "lib/whatsapp_sdk/error"
 
 module WhatsappSdk
   module Resource

--- a/lib/whatsapp_sdk/resource/errors.rb
+++ b/lib/whatsapp_sdk/resource/errors.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "error"
+require "../error"
+# require "lib/whatsapp_sdk/error"
 
 module WhatsappSdk
   module Resource


### PR DESCRIPTION
Replacing `require` to `require_relative` to add the `error` class file and avoid below error:
```
/usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `require': cannot load such file -- error (LoadError)
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /usr/local/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in `require'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/ruby_whatsapp_sdk-dd1e23b3e1f1/lib/whatsapp_sdk/resource/errors.rb:3:in `<main>'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /usr/local/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/core_ext/kernel.rb:26:in `require'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/cref.rb:57:in `const_get'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/cref.rb:57:in `get'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/eager_load.rb:173:in `block in actual_eager_load_dir'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/helpers.rb:47:in `block in ls'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/helpers.rb:25:in `each'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/helpers.rb:25:in `ls'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/eager_load.rb:168:in `actual_eager_load_dir'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/eager_load.rb:16:in `each'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader.rb:413:in `block in eager_load_all'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader.rb:411:in `each'
	from /usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.7.0/lib/zeitwerk/loader.rb:411:in `eager_load_all'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/application/finisher.rb:79:in `block in <module:Finisher>'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/initializable.rb:32:in `instance_exec'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/initializable.rb:32:in `run'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:231:in `block in tsort_each'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:353:in `block (2 levels) in each_strongly_connected_component'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:434:in `each_strongly_connected_component_from'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:352:in `block in each_strongly_connected_component'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:350:in `each'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:350:in `call'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:350:in `each_strongly_connected_component'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:229:in `tsort_each'
	from /usr/local/lib/ruby/3.3.0/tsort.rb:208:in `tsort_each'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/initializable.rb:60:in `run_initializers'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/application.rb:440:in `initialize!'
	from /rails/config/environment.rb:5:in `<main>'
	from config.ru:3:in `require_relative'
	from config.ru:3:in `block (2 levels) in <main>'
	from /usr/local/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:108:in `eval'
	from /usr/local/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:108:in `new_from_string'
	from /usr/local/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:97:in `load_file'
	from /usr/local/bundle/ruby/3.3.0/gems/rack-3.1.8/lib/rack/builder.rb:67:in `parse_file'
	from /usr/local/bundle/ruby/3.3.0/gems/rackup-2.1.0/lib/rackup/server.rb:354:in `build_app_and_options_from_config'
	from /usr/local/bundle/ruby/3.3.0/gems/rackup-2.1.0/lib/rackup/server.rb:263:in `app'
	from /usr/local/bundle/ruby/3.3.0/gems/rackup-2.1.0/lib/rackup/server.rb:424:in `wrapped_app'
	from /usr/local/bundle/ruby/3.3.0/gems/rackup-2.1.0/lib/rackup/server.rb:326:in `block in start'
	from /usr/local/bundle/ruby/3.3.0/gems/rackup-2.1.0/lib/rackup/server.rb:382:in `handle_profiling'
	from /usr/local/bundle/ruby/3.3.0/gems/rackup-2.1.0/lib/rackup/server.rb:325:in `start'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/commands/server/server_command.rb:38:in `start'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/commands/server/server_command.rb:145:in `block in perform'
	from <internal:kernel>:90:in `tap'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/commands/server/server_command.rb:136:in `perform'
	from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
	from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/command/base.rb:178:in `invoke_command'
	from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/command/base.rb:73:in `perform'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/command.rb:65:in `block in invoke'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/command.rb:143:in `with_argv'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/command.rb:63:in `invoke'
	from /usr/local/bundle/ruby/3.3.0/bundler/gems/rails-e00943030911/railties/lib/rails/commands.rb:18:in `<main>'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /usr/local/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from bin/rails:4:in `<main>'
```