### PR TITLE
Added Support Ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
     - 'example.rb'
     - 'tmp/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 3.1
 
 Style/HashSyntax:
   Enabled: false

--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -50,7 +50,7 @@ module WhatsappSdk
       def send_request(endpoint: "", full_url: nil, http_method: "post", params: {}, headers: {}, multipart: false)
         url = full_url || "#{ApiConfiguration::API_URL}/#{@api_version}/"
 
-        faraday_request = faraday(url:, multipart:)
+        faraday_request = faraday(url: url, multipart: multipart)
 
         response = faraday_request.public_send(http_method, endpoint, request_params(params, headers), headers)
 

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -161,9 +161,9 @@ module WhatsappSdk
       def stub_test_request(method_name, body: {}, headers: {}, response_status: 200, response_body: { success: true },
                             api_version: ApiConfiguration::DEFAULT_API_VERSION)
         stub_request(method_name, "#{ApiConfiguration::API_URL}/#{api_version}/test")
-          .with(body:, headers: { 'Accept' => '*/*',
-                                  'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-                                  'Authorization' => 'Bearer test_token' }.merge(headers))
+          .with(body: body, headers: { 'Accept' => '*/*',
+                                       'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                                       'Authorization' => 'Bearer test_token' }.merge(headers))
           .to_return(status: response_status, body: response_body.to_json, headers: {})
       end
 


### PR DESCRIPTION
The 1.x version doesn't support Ruby <3.1.0 because we are using the new Ruby shorthand syntax for hash keys (introduced in Ruby 3.1) where `body:` is equivalent to `body: body,` and the targeting Ruby 2.7 doesn't support this syntax.
