### PR TITLE
Fix false-positive HttpResponseError on bodies containing "error" substring

### DIFF
--- a/lib/whatsapp_sdk/api/client.rb
+++ b/lib/whatsapp_sdk/api/client.rb
@@ -58,13 +58,13 @@ module WhatsappSdk
 
         response = faraday_request.public_send(http_method, endpoint, request_params(params, headers), headers)
 
-        if response.status > 499 || Api::Responses::GenericErrorResponse.response_error?(response: response.body)
-          raise Api::Responses::HttpResponseError.new(http_status: response.status, body: JSON.parse(response.body))
+        parsed_body = parse_response_body(response.body)
+
+        if response.status > 499 || Api::Responses::GenericErrorResponse.response_error?(response: parsed_body)
+          raise Api::Responses::HttpResponseError.new(http_status: response.status, body: parsed_body)
         end
 
-        return nil if response.body == ""
-
-        JSON.parse(response.body)
+        parsed_body
       end
 
       def download_file(url:, content_type_header:, file_path: nil)
@@ -84,6 +84,12 @@ module WhatsappSdk
       end
 
       private
+
+      def parse_response_body(body)
+        return nil if body.nil? || body.empty?
+
+        JSON.parse(body)
+      end
 
       def request_params(params, headers)
         return params.to_json if params.is_a?(Hash) && headers['Content-Type'] == 'application/json'

--- a/lib/whatsapp_sdk/api/responses/generic_error_response.rb
+++ b/lib/whatsapp_sdk/api/responses/generic_error_response.rb
@@ -16,6 +16,8 @@ module WhatsappSdk
         end
 
         def self.response_error?(response:)
+          return false unless response.is_a?(Hash)
+
           response["error"]
         end
 

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -51,6 +51,48 @@ module WhatsappSdk
         assert_nil(response_body)
       end
 
+      # Regression: a 200 response whose body text contains the substring "error" (e.g.
+      # inside a WhatsApp template body) must not be treated as an error. Previously the
+      # client passed the raw body String to `response_error?`, which delegated to
+      # `String#[]` — a substring scan — and raised HttpResponseError for any body
+      # containing the word "error".
+      def test_send_request_does_not_raise_when_body_text_contains_error_substring
+        payload = {
+          'data' => [{
+            'name' => 'dia_push',
+            'components' => [{ 'type' => 'BODY', 'text' => 'si tu cupón te da algún error, avísanos' }]
+          }]
+        }
+        stub_test_request(:get, response_body: payload)
+
+        response_body = @client.send_request(endpoint: 'test', http_method: 'get')
+
+        assert_equal(payload, response_body)
+      end
+
+      def test_send_request_raises_when_response_has_error_key
+        error_body = { 'error' => { 'message' => 'Invalid OAuth token', 'code' => 190 } }
+        stub_test_request(:get, response_status: 400, response_body: error_body)
+
+        error = assert_raises(Api::Responses::HttpResponseError) do
+          @client.send_request(endpoint: 'test', http_method: 'get')
+        end
+
+        assert_equal(400, error.http_status)
+        assert_equal(error_body, error.body)
+      end
+
+      def test_send_request_raises_for_5xx_responses
+        error_body = { 'error' => { 'message' => 'Internal server error' } }
+        stub_test_request(:get, response_status: 502, response_body: error_body)
+
+        error = assert_raises(Api::Responses::HttpResponseError) do
+          @client.send_request(endpoint: 'test', http_method: 'get')
+        end
+
+        assert_equal(502, error.http_status)
+      end
+
       def test_set_api_version_in_config
         WhatsappSdk.configure do |config|
           config.api_version = 'v16.0'

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -51,11 +51,6 @@ module WhatsappSdk
         assert_nil(response_body)
       end
 
-      # Regression: a 200 response whose body text contains the substring "error" (e.g.
-      # inside a WhatsApp template body) must not be treated as an error. Previously the
-      # client passed the raw body String to `response_error?`, which delegated to
-      # `String#[]` — a substring scan — and raised HttpResponseError for any body
-      # containing the word "error".
       def test_send_request_does_not_raise_when_body_text_contains_error_substring
         payload = {
           'data' => [{

--- a/test/whatsapp/api/responses/generic_error_response_test.rb
+++ b/test/whatsapp/api/responses/generic_error_response_test.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'api/responses/generic_error_response'
+
+module WhatsappSdk
+  module Api
+    module Responses
+      class GenericErrorResponseTest < Minitest::Test
+        def test_response_error_returns_truthy_for_hash_with_error_key
+          response = { "error" => { "message" => "Invalid OAuth token", "code" => 190 } }
+          assert_equal({ "message" => "Invalid OAuth token", "code" => 190 },
+                       GenericErrorResponse.response_error?(response: response))
+        end
+
+        def test_response_error_returns_nil_for_hash_without_error_key
+          response = { "data" => [{ "id" => "1" }] }
+          assert_nil(GenericErrorResponse.response_error?(response: response))
+        end
+
+        # Regression guard: a raw JSON string that happens to contain the substring "error"
+        # (e.g. inside a template body) must NOT trigger an error. Previously String#[] was
+        # used as a substring scan, causing false positives for any 200 response body
+        # mentioning the word "error".
+        def test_response_error_returns_false_for_string_input
+          body = '{"data":[{"text":"si tu cupón te da algún error, avísanos"}]}'
+          assert_equal(false, GenericErrorResponse.response_error?(response: body))
+        end
+
+        def test_response_error_returns_false_for_nil_input
+          assert_equal(false, GenericErrorResponse.response_error?(response: nil))
+        end
+      end
+    end
+  end
+end

--- a/test/whatsapp/api/responses/generic_error_response_test.rb
+++ b/test/whatsapp/api/responses/generic_error_response_test.rb
@@ -19,10 +19,6 @@ module WhatsappSdk
           assert_nil(GenericErrorResponse.response_error?(response: response))
         end
 
-        # Regression guard: a raw JSON string that happens to contain the substring "error"
-        # (e.g. inside a template body) must NOT trigger an error. Previously String#[] was
-        # used as a substring scan, causing false positives for any 200 response body
-        # mentioning the word "error".
         def test_response_error_returns_false_for_string_input
           body = '{"data":[{"text":"si tu cupón te da algún error, avísanos"}]}'
           assert_equal(false, GenericErrorResponse.response_error?(response: body))


### PR DESCRIPTION
## Summary

`Client#send_request` raises `HttpResponseError` for any successful (2xx) response whose **raw body String** contains the literal substring `error` anywhere — including inside template body text, marketing copy, or field names. The error envelope does not need to be present.

## Root cause

In `lib/whatsapp_sdk/api/client.rb` the error check runs on the unparsed body:

```ruby
response = faraday_request.public_send(...)

if response.status > 499 || Api::Responses::GenericErrorResponse.response_error?(response: response.body)
  raise Api::Responses::HttpResponseError.new(http_status: response.status, body: JSON.parse(response.body))
end
```

There is no JSON response middleware in the Faraday stack, so `response.body` here is a `String`. `GenericErrorResponse.response_error?` is:

```ruby
def self.response_error?(response:)
  response["error"]
end
```

On a `String`, `response["error"]` invokes `String#[]` with a `String` argument — a **substring search** that returns the matched substring (truthy) if `"error"` is found anywhere, or `nil` otherwise. Result: any 2xx response body containing the word `error` raises `HttpResponseError(http_status: 200, body: <full payload>)`, even though the response is a perfectly valid JSON document with a `data` array and no `error` key.

### Real-world reproduction

A WhatsApp template list (`GET /{business_id}/message_templates`) returns 200 with a payload like:

```json
{
  "data": [
    {
      "name": "dia_push",
      "components": [
        { "type": "BODY", "text": "si tu cupón te da algún error, avísanos" }
      ]
    }
  ]
}
```

This raises `HttpResponseError` purely because the Spanish marketing text contains the word `error`. The exception's own `body` field shows the parsed payload has no `error` key — confirming the failure mode.

## Fix

Two small changes:

1. **`Client#send_request`** — parse the body once into a Hash before the error check, and pass the Hash (not the raw String) to `response_error?`. Empty bodies parse to `nil`.
2. **`GenericErrorResponse.response_error?`** — guard against non-Hash input (`return false unless response.is_a?(Hash)`) so the substring-scan bug can't recur from any caller, present or future.

Behavior preserved:
- 5xx responses still raise `HttpResponseError`.
- 2xx responses with a genuine `error` JSON key still raise (Meta's "200 with warning envelope" case continues to be surfaced).
- 2xx responses with no `error` key no longer false-positive on body text.
- `DELETE`/204 with empty body still returns `nil`.

All 159 existing tests continue to pass.

## Tests added (7 new)

**`test/whatsapp/api/responses/generic_error_response_test.rb`** (new file)
- `test_response_error_returns_truthy_for_hash_with_error_key`
- `test_response_error_returns_nil_for_hash_without_error_key`
- `test_response_error_returns_false_for_string_input` — regression guard for the substring scan
- `test_response_error_returns_false_for_nil_input`

**`test/whatsapp/api/client_test.rb`** (additions)
- `test_send_request_does_not_raise_when_body_text_contains_error_substring` — reproduces the original bug on the real call path; fails on `main`, passes here
- `test_send_request_raises_when_response_has_error_key` — confirms genuine error envelopes still raise
- `test_send_request_raises_for_5xx_responses` — confirms server-error path is unchanged

## Test plan

- [x] `bundle exec rake test` — 166 runs, 570 assertions, 0 failures, 0 errors, 1 skip
- [x] All 7 new tests pass; all 159 pre-existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)