### PR TITLE
Guard build_from_response against non-Hash input (e.g. 5xx empty body)

### DIFF
--- a/lib/whatsapp_sdk/api/responses/generic_error_response.rb
+++ b/lib/whatsapp_sdk/api/responses/generic_error_response.rb
@@ -22,6 +22,8 @@ module WhatsappSdk
         end
 
         def self.build_from_response(response:)
+          return unless response.is_a?(Hash)
+
           error_response = response["error"]
           return unless error_response
 

--- a/test/whatsapp/api/client_test.rb
+++ b/test/whatsapp/api/client_test.rb
@@ -88,6 +88,19 @@ module WhatsappSdk
         assert_equal(502, error.http_status)
       end
 
+      def test_send_request_raises_http_response_error_for_5xx_with_empty_body
+        stub_request(:get, "#{ApiConfiguration::API_URL}/#{ApiConfiguration::DEFAULT_API_VERSION}/test")
+          .to_return(status: 503, body: "", headers: {})
+
+        error = assert_raises(Api::Responses::HttpResponseError) do
+          @client.send_request(endpoint: 'test', http_method: 'get')
+        end
+
+        assert_equal(503, error.http_status)
+        assert_nil(error.body)
+        assert_nil(error.error_info)
+      end
+
       def test_set_api_version_in_config
         WhatsappSdk.configure do |config|
           config.api_version = 'v16.0'

--- a/test/whatsapp/api/responses/generic_error_response_test.rb
+++ b/test/whatsapp/api/responses/generic_error_response_test.rb
@@ -27,6 +27,27 @@ module WhatsappSdk
         def test_response_error_returns_false_for_nil_input
           assert_equal(false, GenericErrorResponse.response_error?(response: nil))
         end
+
+        def test_build_from_response_returns_instance_for_hash_with_error_key
+          response = { "error" => { "message" => "Invalid OAuth token", "code" => 190 } }
+          result = GenericErrorResponse.build_from_response(response: response)
+          assert_instance_of(GenericErrorResponse, result)
+          assert_equal(190, result.code)
+          assert_equal("Invalid OAuth token", result.message)
+        end
+
+        def test_build_from_response_returns_nil_for_hash_without_error_key
+          response = { "data" => [{ "id" => "1" }] }
+          assert_nil(GenericErrorResponse.build_from_response(response: response))
+        end
+
+        def test_build_from_response_returns_nil_for_nil_input
+          assert_nil(GenericErrorResponse.build_from_response(response: nil))
+        end
+
+        def test_build_from_response_returns_nil_for_string_input
+          assert_nil(GenericErrorResponse.build_from_response(response: '{"error":"x"}'))
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Follow-up to #194 (per [review comment](https://github.com/ignacio-chiazzo/ruby_whatsapp_sdk/pull/194#discussion_r3306628708)). Adds the same non-Hash guard to `GenericErrorResponse.build_from_response` that #194 added to `response_error?`, so a 5xx response with an empty body surfaces cleanly as `HttpResponseError` instead of being masked by a `NoMethodError`.

## Bug

After #194, `Client#send_request` parses the body before raising:

```ruby
parsed_body = parse_response_body(response.body)   # nil for empty body

if response.status > 499 || ...
  raise Api::Responses::HttpResponseError.new(http_status: response.status, body: parsed_body)
end
```

`HttpResponseError#initialize` then calls:

```ruby
GenericErrorResponse.build_from_response(response: body)   # body is nil
```

…which does `response["error"]` on `nil`, raising:

```
NoMethodError: undefined method `[]' for nil
```

So callers of a 5xx-with-empty-body endpoint receive `NoMethodError` instead of `HttpResponseError` — the wrong exception type, with no http_status and no body attached.

Reproducer (this test fails on `main` and on #194's branch without this fix):

```ruby
# 503 with empty body
[WhatsappSdk::Api::Responses::HttpResponseError] exception expected, not
Class: <NoMethodError>
Message: <"undefined method `[]' for nil">
```

## Fix

Mirror the `is_a?(Hash)` guard already present on `response_error?`:

```ruby
def self.build_from_response(response:)
  return unless response.is_a?(Hash)

  error_response = response["error"]
  return unless error_response

  new(response: error_response)
end
```

Behavior:
- Hash with `error` key → returns `GenericErrorResponse` (unchanged).
- Hash without `error` key → returns `nil` (unchanged).
- `nil` / `String` / any non-Hash → returns `nil` (previously raised).

## Tests added (5 new)

**`test/whatsapp/api/responses/generic_error_response_test.rb`**
- `test_build_from_response_returns_instance_for_hash_with_error_key`
- `test_build_from_response_returns_nil_for_hash_without_error_key`
- `test_build_from_response_returns_nil_for_nil_input` — regression
- `test_build_from_response_returns_nil_for_string_input` — symmetric guard

**`test/whatsapp/api/client_test.rb`**
- `test_send_request_raises_http_response_error_for_5xx_with_empty_body` — end-to-end regression: asserts the right exception type, the http_status, and that `error_info` is `nil` (not raising).

## Test plan

- [x] `bundle exec rake test` — 171 runs, 0 failures, 1 skip
- [x] Verified the new client-level test fails on the pre-fix branch with `NoMethodError`, passes here.

## Notes

This depends on #194 being merged first. Once #194 is in, the diff vs `main` will be limited to the changes described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)